### PR TITLE
Make docker image able to run on arm hardware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+pom.xml.versionsBackup
 nohup.out
 .install
 target/

--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ dev:
 	mvn quarkus:dev -pl slushy
 
 docker: clean install
-	cd slushy && docker build -f src/main/docker/Dockerfile.jvm -t kemitix/slushy .
+	cd slushy && docker build -f src/main/docker/Dockerfile -t kemitix/slushy .

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ https://search.maven.org/search?q=g:net.kemitix.slushy%20a:slushy)
 
 Define the following environment variables to configure Slushy:
 
+* `TRELLO_KEY` - the Trello API access key
+* `TRELLO_SECRET` - the Trello API secret key
 * `SLUSHY_BOARD` - the Trello Board
 * `SLUSHY_USER` - the Trello User name
 * `SLUSHY_READER` - the email to send attachements to

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy-root</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 
     <modules>
         <module>slushy</module>

--- a/set-version.sh
+++ b/set-version.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+if test $# != 1
+then
+  echo "ERROR: version missing"
+  exit 255
+fi
+
+VERSION=$1
+
+for P in . slushy-parent slushy
+do
+  mvn versions:set -DnewVersion=$VERSION -pl $P
+done

--- a/slushy-app/pom.xml
+++ b/slushy-app/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>slushy-parent</artifactId>
         <groupId>net.kemitix.slushy</groupId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
         <relativePath>../slushy-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/slushy-parent/pom.xml
+++ b/slushy-parent/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy-parent</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/slushy-spi/pom.xml
+++ b/slushy-spi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>slushy-parent</artifactId>
         <groupId>net.kemitix.slushy</groupId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
         <relativePath>../slushy-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/slushy.sh
+++ b/slushy.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 docker run -d --rm \
+       --name slushy \
        -e TRELLO_KEY \
        -e TRELLO_SECRET \
        -e SLUSHY_USER \

--- a/slushy.sh
+++ b/slushy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-docker run -i --rm \
+docker run -d --rm \
        -e TRELLO_KEY \
        -e TRELLO_SECRET \
        -e SLUSHY_USER \

--- a/slushy/pom.xml
+++ b/slushy/pom.xml
@@ -69,6 +69,7 @@
     </dependency>
   </dependencies>
   <build>
+    <finalName>slushy</finalName>
     <plugins>
       <plugin>
         <groupId>io.quarkus</groupId>

--- a/slushy/pom.xml
+++ b/slushy/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.kemitix.slushy</groupId>
   <artifactId>slushy</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/slushy/src/main/docker/Dockerfile
+++ b/slushy/src/main/docker/Dockerfile
@@ -1,0 +1,31 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
+#
+# Before building the docker image run:
+#
+# mvn package
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile -t kemitix/slushy .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 9999:8080 kemitix/slushy
+#
+# If you want to include the debug port into your docker image
+# you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5050
+#
+# Then run the container using :
+#
+# docker run -i --rm -p 9999:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" kemitix/slushy
+#
+###
+FROM adoptopenjdk:latest
+
+WORKDIR /app
+
+COPY target/lib /app/lib/
+COPY target/slushy-runner.jar /app/
+
+CMD ["java", "-jar", "/app/slushy-runner.jar"]


### PR DESCRIPTION
The default Dockerfiles provided with Quarkus use a base image that doesn't support arm architecture.