### PR TITLE
Use the trello card id as the unique file prefix before sending to reader

### DIFF
--- a/slushy-app/src/main/java/net/kemitix/slushy/app/TrelloAttachment.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/TrelloAttachment.java
@@ -9,7 +9,6 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.channels.Channels;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 
 public class TrelloAttachment implements Attachment {
@@ -19,11 +18,10 @@ public class TrelloAttachment implements Attachment {
                     TrelloAttachment.class.getName());
 
     private static final String[] EXTENSIONS = new String[]{"doc", "docx", "odt"};
-    private static final AtomicInteger SEQUENCE_COUNTER = new AtomicInteger();
     private final com.julienvey.trello.domain.Attachment attachment;
     private final Card card;
     private final AttachmentDirectory attachmentDirectory;
-    private final int sequence;
+    private final String id;
 
     private TrelloAttachment(
             com.julienvey.trello.domain.Attachment attachment,
@@ -33,7 +31,7 @@ public class TrelloAttachment implements Attachment {
         this.attachment = attachment;
         this.card = card;
         this.attachmentDirectory = attachmentDirectory;
-        this.sequence = SEQUENCE_COUNTER.incrementAndGet();
+        this.id = card.getIdShort();
     }
 
     public static Attachment create(
@@ -46,8 +44,8 @@ public class TrelloAttachment implements Attachment {
 
     @Override
     public File getFileName() {
-        return new File(String.format("%2d - %s.%s",
-                sequence, card.getName(), extension()));
+        return new File(String.format("%4s - %s.%s",
+                id, card.getName(), extension()));
     }
 
     private String extension() {


### PR DESCRIPTION
Provides a stable ordered ID for attachments that won’t reset should the application need to be restarted.