### PR TITLE
Reformat cards before checking for multiple-submissions

### DIFF
--- a/slushy/src/main/resources/application.properties
+++ b/slushy/src/main/resources/application.properties
@@ -9,8 +9,8 @@ slushy.inbox.slush-name = Slush
 slushy.inbox.due-days = 30
 slushy.inbox.routing-slip = \
   direct:Slushy.Inbox.Parse,\
-  direct:Slushy.MultiSubMonitor,\
   direct:Slushy.Inbox.Reformat,\
+  direct:Slushy.MultiSubMonitor,\
   direct:Slushy.AddMember,\
   direct:Slushy.DueIn30Days,\
   direct:Slushy.Inbox.MoveToSlushPile,\


### PR DESCRIPTION
Cards being detected as a multiple-submission are not reformated.