### PR TITLE
Remove RTF and PDF from accepted format

### DIFF
--- a/slushy-app/src/main/java/net/kemitix/slushy/app/ValidFileTypes.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/ValidFileTypes.java
@@ -12,14 +12,13 @@ public class ValidFileTypes {
 
     // Amazon supports sending to a Kindle:
     // https://www.amazon.co.uk/gp/help/customer/display.html?nodeId=200767340
+    // Excludes PDF and RTF as they are rejected despite the documentation
     public static final List<String> KINDLE_SUPPORTED = List.of(
             "docx", "doc",
-            "pdf",
             "txt",
             "azw",
             "mobi",
-            "html", "htm",
-            "rtf"
+            "html", "htm"
     );
 
     private final ConversionService conversionService;

--- a/slushy-app/src/test/java/net/kemitix/slushy/app/inbox/SubmissionParserTest.java
+++ b/slushy-app/src/test/java/net/kemitix/slushy/app/inbox/SubmissionParserTest.java
@@ -144,8 +144,9 @@ public class SubmissionParserTest
         //        Kindle Format (.MOBI, .AZW)
         //        Microsoft Word (.DOC, .DOCX)
         //        HTML (.HTML, .HTM)
-        //        RTF (.RTF)
         //        Text (.TXT)
+        // The following types claim to be supported by Kindle, but aren't
+        //        RTF (.RTF)
         //        PDF (.PDF)
         // The following types are supported by Kindle, but we don't want them
         //        JPEG (.JPEG, .JPG)
@@ -154,7 +155,7 @@ public class SubmissionParserTest
         //        BMP (.BMP)
         @ParameterizedTest
         @DisplayName("Accepts Kindle supported types")
-        @ValueSource(strings = {"MOBI", "AZW", "DOC", "DOCX", "HTML", "HTM", "RTF", "TXT", "PDF"})
+        @ValueSource(strings = {"MOBI", "AZW", "DOC", "DOCX", "HTML", "HTM", "TXT"})
         public void acceptsKindleTypes(String type) {
             documentUrl = "document." + type;
             given(trelloBoard.getAttachments(card))


### PR DESCRIPTION
Despite what Amazon's documentation says you can't send RTF or PDF files to kindle as attachments.