### PR TITLE
emaili confirmations form inbox are not being sent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy-root</artifactId>
     <packaging>pom</packaging>
-    <version>1.7.0</version>
+    <version>1.7.1</version>
 
     <modules>
         <module>slushy</module>

--- a/slushy-app/pom.xml
+++ b/slushy-app/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>slushy-parent</artifactId>
         <groupId>net.kemitix.slushy</groupId>
-        <version>1.7.0</version>
+        <version>1.7.1</version>
         <relativePath>../slushy-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/slushy-parent/pom.xml
+++ b/slushy-parent/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy-parent</artifactId>
-    <version>1.7.0</version>
+    <version>1.7.1</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/slushy/pom.xml
+++ b/slushy/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.kemitix.slushy</groupId>
   <artifactId>slushy</artifactId>
-  <version>1.7.0</version>
+  <version>1.7.1</version>
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/slushy/src/main/resources/application.properties
+++ b/slushy/src/main/resources/application.properties
@@ -14,6 +14,7 @@ slushy.inbox.routing-slip = \
   direct:Slushy.ValidateAttachment,\
   direct:Slushy.MultiSubMonitor,\
   direct:Slushy.DueIn30Days,\
+  direct:Slushy.Inbox.SendEmailConfirmation,\
   direct:Slushy.Inbox.MoveToTargetList,\
   direct:Slushy.AddMember
 


### PR DESCRIPTION
Some time after 3 Sep at 18:46 email notifications stopped being sent for submissions received via the Inbox.

Broken by #30: when reworking the Inbox routing slip, the entry `direct:Slushy.Inbox.SendEmailConfirmation` was removed.