### PR TITLE
Improve reliability

### DIFF
--- a/slushy-app/src/main/java/net/kemitix/slushy/app/ListProcessConfig.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/ListProcessConfig.java
@@ -5,7 +5,7 @@ public interface ListProcessConfig {
     /**
      * How often, in seconds, to scan the list.
      */
-    String getScanPeriod();
+    long getScanPeriod();
 
     /**
      * The name of the list to scan.
@@ -27,5 +27,20 @@ public interface ListProcessConfig {
      * before being processed.
      */
     int getRequiredAgeHours();
+
+    /**
+     * The maximum redeliveries.
+     *
+     * <p>Derived from the scan period and retry delay, so that retries will
+     * occur until the next scan period starts.</p>
+     */
+    default int getMaxRetries() {
+        return (int) Math.floorDiv(getScanPeriod(), getRetryDelay());
+    }
+
+    /**
+     * The initial redelivery delay in milliseconds.
+     */
+    long getRetryDelay();
 
 }

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/OnException.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/OnException.java
@@ -1,0 +1,18 @@
+package net.kemitix.slushy.app;
+
+import org.apache.camel.builder.RouteBuilder;
+
+import java.io.IOException;
+
+public class OnException {
+
+    public static void retry(
+            RouteBuilder routeBuilder,
+            ListProcessConfig config
+    ) {
+        routeBuilder
+                .onException(IOException.class)
+                .maximumRedeliveries(config.getMaxRetries())
+                .redeliveryDelay(config.getRetryDelay());
+    }
+}

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/archiver/ArchiverRoutes.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/archiver/ArchiverRoutes.java
@@ -1,6 +1,7 @@
 package net.kemitix.slushy.app.archiver;
 
 import net.kemitix.slushy.app.IsRequiredAge;
+import net.kemitix.slushy.app.OnException;
 import net.kemitix.slushy.app.trello.TrelloBoard;
 import org.apache.camel.builder.RouteBuilder;
 
@@ -20,6 +21,8 @@ public class ArchiverRoutes
 
     @Override
     public void configure() {
+        OnException.retry(this, archiverConfig);
+
         fromF("timer:archiver?period=%s", archiverConfig.getScanPeriod())
                 .routeId("Slushy.Archiver")
                 .setBody(exchange -> trelloBoard.getListCards(archiverConfig.getSourceList()))

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/hold/HoldRoutes.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/hold/HoldRoutes.java
@@ -3,6 +3,7 @@ package net.kemitix.slushy.app.hold;
 import net.kemitix.slushy.app.MoveCard;
 import net.kemitix.slushy.app.AddComment;
 import net.kemitix.slushy.app.IsRequiredAge;
+import net.kemitix.slushy.app.OnException;
 import net.kemitix.slushy.app.SlushyConfig;
 import net.kemitix.slushy.app.email.SendEmail;
 import net.kemitix.slushy.app.trello.TrelloBoard;
@@ -27,6 +28,8 @@ public class HoldRoutes
 
     @Override
     public void configure() {
+        OnException.retry(this, holdConfig);
+
         fromF("timer:hold?period=%s", holdConfig.getScanPeriod())
                 .routeId("Slushy.Hold")
                 .setBody(exchange -> trelloBoard.getListCards(holdConfig.getSourceList()))

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/inbox/InboxRoutes.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/inbox/InboxRoutes.java
@@ -3,6 +3,7 @@ package net.kemitix.slushy.app.inbox;
 import net.kemitix.slushy.app.MoveCard;
 import net.kemitix.slushy.app.AddComment;
 import net.kemitix.slushy.app.IsRequiredAge;
+import net.kemitix.slushy.app.OnException;
 import net.kemitix.slushy.app.SlushyConfig;
 import net.kemitix.slushy.app.ParseSubmission;
 import net.kemitix.slushy.app.email.SendEmail;
@@ -11,6 +12,8 @@ import org.apache.camel.builder.RouteBuilder;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+
+import java.io.IOException;
 
 import static org.apache.camel.builder.Builder.bean;
 
@@ -30,6 +33,8 @@ public class InboxRoutes
 
     @Override
     public void configure() {
+        OnException.retry(this, inboxConfig);
+
         fromF("timer:inbox?period=%s", inboxConfig.getScanPeriod())
                 .routeId("Slushy.Inbox")
 

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/reader/ReaderRoutes.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/reader/ReaderRoutes.java
@@ -3,6 +3,7 @@ package net.kemitix.slushy.app.reader;
 import net.kemitix.slushy.app.AttachmentLoader;
 import net.kemitix.slushy.app.MoveCard;
 import net.kemitix.slushy.app.AddComment;
+import net.kemitix.slushy.app.OnException;
 import net.kemitix.slushy.app.SlushyConfig;
 import net.kemitix.slushy.app.email.SendEmailAttachment;
 import net.kemitix.slushy.app.trello.TrelloBoard;
@@ -27,6 +28,8 @@ public class ReaderRoutes
 
     @Override
     public void configure() {
+        OnException.retry(this, readerConfig);
+
         fromF("timer:reader?period=%s", readerConfig.getScanPeriod())
                 .routeId("Slushy.Reader")
                 .setBody(exchange -> trelloBoard.getListCards(readerConfig.getSourceList()))

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/reject/RejectRoutes.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/reject/RejectRoutes.java
@@ -3,6 +3,7 @@ package net.kemitix.slushy.app.reject;
 import net.kemitix.slushy.app.MoveCard;
 import net.kemitix.slushy.app.AddComment;
 import net.kemitix.slushy.app.IsRequiredAge;
+import net.kemitix.slushy.app.OnException;
 import net.kemitix.slushy.app.SlushyCard;
 import net.kemitix.slushy.app.SlushyConfig;
 import net.kemitix.slushy.app.email.SendEmail;
@@ -28,6 +29,8 @@ public class RejectRoutes
 
     @Override
     public void configure() {
+        OnException.retry(this, rejectConfig);
+
         fromF("timer:reject?period=%s", rejectConfig.getScanPeriod())
                 .routeId("Slushy.Reject")
                 .setBody(exchange -> trelloBoard.getListCards(rejectConfig.getSourceList()))

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/withdraw/WithdrawRoutes.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/withdraw/WithdrawRoutes.java
@@ -2,6 +2,7 @@ package net.kemitix.slushy.app.withdraw;
 
 import net.kemitix.slushy.app.AddComment;
 import net.kemitix.slushy.app.IsRequiredAge;
+import net.kemitix.slushy.app.OnException;
 import net.kemitix.slushy.app.SlushyConfig;
 import net.kemitix.slushy.app.email.SendEmail;
 import net.kemitix.slushy.app.trello.TrelloBoard;
@@ -25,6 +26,8 @@ public class WithdrawRoutes
 
     @Override
     public void configure() {
+        OnException.retry(this, withdrawConfig);
+
         fromF("timer:withdraw?period=%s", withdrawConfig.getScanPeriod())
                 .routeId("Slushy.Withdraw")
 

--- a/slushy/src/main/java/net/kemitix/slushy/AbstractQuarkusListProcessingConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/AbstractQuarkusListProcessingConfig.java
@@ -2,15 +2,18 @@ package net.kemitix.slushy;
 
 import lombok.Getter;
 import lombok.Setter;
+import net.kemitix.slushy.app.ListProcessConfig;
 
 @Setter
 @Getter
-public abstract class AbstractQuarkusListProcessingConfig {
+public abstract class AbstractQuarkusListProcessingConfig
+        implements ListProcessConfig {
 
-    String scanPeriod;
+    long scanPeriod;
     String sourceList;
     String targetList;
     String routingSlip;
     int requiredAgeHours;
+    long retryDelay;
 
 }

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusSlushyConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusSlushyConfig.java
@@ -3,10 +3,13 @@ package net.kemitix.slushy;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.java.Log;
+import net.kemitix.slushy.app.ListProcessConfig;
 import net.kemitix.slushy.app.SlushyConfig;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
 
 @Log
 @Setter
@@ -22,6 +25,8 @@ public class QuarkusSlushyConfig
     private String sender = System.getenv("SLUSHY_SENDER");
     private String reader = System.getenv("SLUSHY_READER");
 
+    @Inject Instance<ListProcessConfig> listProcessConfigs;
+
     @PostConstruct
     void init() {
         log.info(String.format("TRELLO_KEY: %s", trelloKey));
@@ -30,6 +35,12 @@ public class QuarkusSlushyConfig
         log.info(String.format("SLUSHY_BOARD: %s", boardName));
         log.info(String.format("SLUSHY_SENDER: %s", sender));
         log.info(String.format("SLUSHY_READER: %s", reader));
+        listProcessConfigs.forEach(config ->
+                log.info(String.format(
+                        "[%s] scan every %d seconds; retry: %d times, every %d seconds",
+                        config.getClass().getSimpleName(),
+                        config.getScanPeriod() / 1000,
+                        config.getMaxRetries(), config.getRetryDelay() / 1000)));
     }
 
 }

--- a/slushy/src/main/resources/application.properties
+++ b/slushy/src/main/resources/application.properties
@@ -14,9 +14,9 @@ slushy.inbox.routing-slip = \
   direct:Slushy.ValidateAttachment,\
   direct:Slushy.MultiSubMonitor,\
   direct:Slushy.DueIn30Days,\
-  direct:Slushy.Inbox.SendEmailConfirmation,\
+  direct:Slushy.AddMember,\
   direct:Slushy.Inbox.MoveToTargetList,\
-  direct:Slushy.AddMember
+  direct:Slushy.Inbox.SendEmailConfirmation
 
 slushy.multisub.lists = \
   Slush,\
@@ -36,8 +36,8 @@ slushy.reader.routing-slip = \
   direct:Slushy.CardToSubmission,\
   direct:Slushy.LoadAttachment,\
   direct:Slushy.FormatForReader,\
-  direct:Slushy.SendToReader,\
-  direct:Slushy.Reader.MoveToTargetList
+  direct:Slushy.Reader.MoveToTargetList,\
+  direct:Slushy.SendToReader
 
 # Reject
 # scan period: 1 hour
@@ -47,10 +47,10 @@ slushy.reject.target-list = Rejected
 slushy.reject.required-age-hours = 24
 slushy.reject.routing-slip = \
   direct:Slushy.CardToSubmission,\
-  direct:Slushy.Reject.SendEmail,\
   direct:Slushy.RemoveMember,\
   direct:Slushy.DueCompleted,\
-  direct:Slushy.Reject.MoveToTargetList
+  direct:Slushy.Reject.MoveToTargetList,\
+  direct:Slushy.Reject.SendEmail
 
 # Hold
 # scan period: 1 hour
@@ -60,9 +60,9 @@ slushy.hold.target-list = Held
 slushy.hold.required-age-hours = 24
 slushy.hold.routing-slip = \
   direct:Slushy.CardToSubmission,\
-  direct:Slushy.Hold.SendEmail,\
   direct:Slushy.DueIn60Days,\
-  direct:Slushy.Hold.MoveToTargetList
+  direct:Slushy.Hold.MoveToTargetList,\
+  direct:Slushy.Hold.SendEmail
 
 # Withdraw
 # scan period: 1 hour
@@ -72,9 +72,9 @@ slushy.withdraw.target-list = Withdraw
 slushy.withdraw.required-age-hours = 0
 slushy.withdraw.routing-slip = \
   direct:Slushy.CardToSubmission,\
-  direct:Slushy.Withdraw.SendEmail,\
   direct:Slushy.DueCompleted,\
-  direct:Slushy.ArchiveCard
+  direct:Slushy.ArchiveCard,\
+  direct:Slushy.Withdraw.SendEmail
 
 # Archiver
 # scan period: 1 day

--- a/slushy/src/main/resources/application.properties
+++ b/slushy/src/main/resources/application.properties
@@ -8,6 +8,8 @@ slushy.inbox.source-list = Inbox
 slushy.inbox.target-list = Send to Reader
 slushy.inbox.required-age-hours = 0
 slushy.inbox.due-days = 30
+# retry every minute
+slushy.inbox.retry-delay = 600000
 slushy.inbox.routing-slip = \
   direct:Slushy.CardToSubmission,\
   direct:Slushy.ReformatCard,\
@@ -32,6 +34,8 @@ slushy.reader.scan-period = 300000
 slushy.reader.source-list = Send to Reader
 slushy.reader.target-list = Slush
 slushy.reader.required-age-hours = 0
+# retry every minute
+slushy.reader.retry-delay = 600000
 slushy.reader.routing-slip = \
   direct:Slushy.CardToSubmission,\
   direct:Slushy.LoadAttachment,\
@@ -45,6 +49,8 @@ slushy.reject.scan-period = 3600000
 slushy.reject.source-list = Reject
 slushy.reject.target-list = Rejected
 slushy.reject.required-age-hours = 24
+# retry every minute
+slushy.reject.retry-delay = 600000
 slushy.reject.routing-slip = \
   direct:Slushy.CardToSubmission,\
   direct:Slushy.RemoveMember,\
@@ -58,6 +64,8 @@ slushy.hold.scan-period = 3600000
 slushy.hold.source-list = Hold
 slushy.hold.target-list = Held
 slushy.hold.required-age-hours = 24
+# retry every minute
+slushy.hold.retry-delay = 600000
 slushy.hold.routing-slip = \
   direct:Slushy.CardToSubmission,\
   direct:Slushy.DueIn60Days,\
@@ -70,6 +78,8 @@ slushy.withdraw.scan-period = 3600000
 slushy.withdraw.source-list = Withdraw
 slushy.withdraw.target-list = Withdraw
 slushy.withdraw.required-age-hours = 0
+# retry every minute
+slushy.withdraw.retry-delay = 600000
 slushy.withdraw.routing-slip = \
   direct:Slushy.CardToSubmission,\
   direct:Slushy.DueCompleted,\
@@ -83,6 +93,8 @@ slushy.archiver.source-list = Rejected
 slushy.archiver.target-list = Rejected
 # 21 days in hours
 slushy.archiver.required-age-hours = 504
+# retry every minute
+slushy.archiver.retry-delay = 600000
 slushy.archiver.routing-slip = \
   direct:Slushy.CardToSubmission,\
   direct:Slushy.ArchiveCard


### PR DESCRIPTION
* Don't send email to the author until all other steps have succeeded. Those earlier steps are idempotent, but sending the email isn't.
* When there is an `IOException`, e.g. network error talking to Trello or AWS, then retry. Retries will happen at the configured interval until the next scan period starts.