### PR TITLE
Adjust retry frequencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy-root</artifactId>
     <packaging>pom</packaging>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
 
     <modules>
         <module>slushy</module>

--- a/slushy-app/pom.xml
+++ b/slushy-app/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>slushy-parent</artifactId>
         <groupId>net.kemitix.slushy</groupId>
-        <version>1.8.0</version>
+        <version>1.8.1</version>
         <relativePath>../slushy-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/IsRequiredAge.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/IsRequiredAge.java
@@ -22,7 +22,7 @@ public class IsRequiredAge {
     @Handler
     boolean isRested(
             @NonNull @Body SlushyCard card,
-            @NonNull @Header("SlushyRequiredAge") int requiredAgeHours
+            @NonNull @Header("SlushyRequiredAge") Integer requiredAgeHours
     ) {
         Instant requiredAge = now.get()
                 .minus(requiredAgeHours, ChronoUnit.HOURS);

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/duedates/SetDueInDays.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/duedates/SetDueInDays.java
@@ -19,7 +19,7 @@ public class SetDueInDays {
 
     void setDueDate(
             @NonNull @Header("SlushyCard") SlushyCard card,
-            @NonNull @Header("SlushyDueInDays") int days
+            @NonNull @Header("SlushyDueInDays") Integer days
     ) {
         card.setDue(Date.from(now.get().plus(days, ChronoUnit.DAYS)));
         trelloBoard.updateCard(card);

--- a/slushy-parent/pom.xml
+++ b/slushy-parent/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy-parent</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/slushy/pom.xml
+++ b/slushy/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.kemitix.slushy</groupId>
   <artifactId>slushy</artifactId>
-  <version>1.8.0</version>
+  <version>1.8.1</version>
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusSlushyConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusSlushyConfig.java
@@ -47,9 +47,13 @@ public class QuarkusSlushyConfig
 
     private String timeAsEnglish(long millis) {
         long seconds = millis / 1000;
-        long mins = Math.floorDiv(seconds, 60);
+        long hours = Math.floorDiv(seconds, 60 * 60);
+        long mins = Math.floorDiv(seconds - (hours * 60 * 60), 60);
         long secs = Math.floorMod(seconds, 60);
         List<String> fragments = new ArrayList<>();
+        if (hours > 0) {
+            fragments.add(String.format("%d hours", hours));
+        }
         if (mins > 0) {
             fragments.add(String.format("%d minutes", mins));
         }

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusSlushyConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusSlushyConfig.java
@@ -10,6 +10,8 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
 
 @Log
 @Setter
@@ -37,10 +39,24 @@ public class QuarkusSlushyConfig
         log.info(String.format("SLUSHY_READER: %s", reader));
         listProcessConfigs.forEach(config ->
                 log.info(String.format(
-                        "[%s] scan every %d seconds; retry: %d times, every %d seconds",
+                        "[%s] scan every %s; retry: %d times, every %s",
                         config.getClass().getSimpleName(),
-                        config.getScanPeriod() / 1000,
-                        config.getMaxRetries(), config.getRetryDelay() / 1000)));
+                        timeAsEnglish(config.getScanPeriod()),
+                        config.getMaxRetries(), timeAsEnglish(config.getRetryDelay()))));
+    }
+
+    private String timeAsEnglish(long millis) {
+        long seconds = millis / 1000;
+        long mins = Math.floorDiv(seconds, 60);
+        long secs = Math.floorMod(seconds, 60);
+        List<String> fragments = new ArrayList<>();
+        if (mins > 0) {
+            fragments.add(String.format("%d minutes", mins));
+        }
+        if (secs > 0) {
+            fragments.add(String.format("%s seconds", secs));
+        }
+        return String.join(" ", fragments);
     }
 
 }

--- a/slushy/src/main/resources/application.properties
+++ b/slushy/src/main/resources/application.properties
@@ -35,7 +35,7 @@ slushy.reader.source-list = Send to Reader
 slushy.reader.target-list = Slush
 slushy.reader.required-age-hours = 0
 # retry every minute
-slushy.reader.retry-delay = 600000
+slushy.reader.retry-delay = 60000
 slushy.reader.routing-slip = \
   direct:Slushy.CardToSubmission,\
   direct:Slushy.LoadAttachment,\

--- a/slushy/src/main/resources/application.properties
+++ b/slushy/src/main/resources/application.properties
@@ -93,8 +93,8 @@ slushy.archiver.source-list = Rejected
 slushy.archiver.target-list = Rejected
 # 21 days in hours
 slushy.archiver.required-age-hours = 504
-# retry every minute
-slushy.archiver.retry-delay = 600000
+# retry every 4 hours
+slushy.archiver.retry-delay = 14400000
 slushy.archiver.routing-slip = \
   direct:Slushy.CardToSubmission,\
   direct:Slushy.ArchiveCard

--- a/slushy/src/main/resources/application.properties
+++ b/slushy/src/main/resources/application.properties
@@ -9,7 +9,7 @@ slushy.inbox.target-list = Send to Reader
 slushy.inbox.required-age-hours = 0
 slushy.inbox.due-days = 30
 # retry every minute
-slushy.inbox.retry-delay = 600000
+slushy.inbox.retry-delay = 60000
 slushy.inbox.routing-slip = \
   direct:Slushy.CardToSubmission,\
   direct:Slushy.ReformatCard,\


### PR DESCRIPTION
Currently:
```
[QuarkusHoldConfig] scan every 3600 seconds; retry: 6 times, every 600 seconds (1 hr - 10 mins)
[QuarkusWithdrawConfig] scan every 3600 seconds; retry: 6 times, every 600 seconds (1 hr - 10 mins)
[QuarkusInboxConfig] scan every 300 seconds; retry: 0 times, every 600 seconds (5 mins - 10 mins) !!!
[QuarkusReaderConfig] scan every 300 seconds; retry: 0 times, every 600 seconds (5 mins - 10 mins) !!!
[QuarkusRejectConfig] scan every 3600 seconds; retry: 6 times, every 600 seconds (1 hr - 10 mins)
[QuarkusArchiverConfig] scan every 86400 seconds; retry: 144 times, every 600 seconds (1 day(?) - 10 mins)
```
- [x] Express config in log messages in minutes rather than seconds
- [x] Inbox retry every minute
- [x] Reader retry every minute
- [x] Archiver retry every 4 hours