### PR TITLE
Reader: Limit Cards in Slushpile (i.e. on Kindle)

### DIFF
--- a/slushy-app/src/main/java/net/kemitix/slushy/app/reader/LimitTargetSizeRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/reader/LimitTargetSizeRoute.java
@@ -1,0 +1,27 @@
+package net.kemitix.slushy.app.reader;
+
+import org.apache.camel.builder.RouteBuilder;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+/**
+ * Aborts the routing slip if the target list already contains the max limit
+ * of cards.
+ */
+@ApplicationScoped
+public class LimitTargetSizeRoute
+        extends RouteBuilder {
+    @Inject ReaderIsFull readerIsFull;
+    @Override
+    public void configure() {
+        from("direct:Slushy.Reader.LimitTargetSize")
+                .routeId("Slushy.Reader.LimitTargetSize")
+                .choice()
+                .when()
+                .method(readerIsFull)
+                .process(exchange -> exchange.setRouteStop(true))
+                .end()
+        ;
+    }
+}

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/reader/ReaderConfig.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/reader/ReaderConfig.java
@@ -4,4 +4,10 @@ import net.kemitix.slushy.app.ListProcessConfig;
 
 public interface ReaderConfig extends ListProcessConfig {
 
+    /**
+     * The maximum number of cards to place in the list.
+     *
+     * <p>A value of -1 means there is no limit.</p>
+     */
+    int getMaxSize();
 }

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/reader/ReaderIsFull.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/reader/ReaderIsFull.java
@@ -1,0 +1,26 @@
+package net.kemitix.slushy.app.reader;
+
+import net.kemitix.slushy.app.trello.TrelloBoard;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class ReaderIsFull {
+    private final ReaderConfig readerConfig;
+    private final TrelloBoard trelloBoard;
+
+    @Inject
+    public ReaderIsFull(ReaderConfig readerConfig, TrelloBoard trelloBoard) {
+        this.readerConfig = readerConfig;
+        this.trelloBoard = trelloBoard;
+    }
+
+    boolean test() {
+        if (readerConfig.getMaxSize() == -1){
+            return false;
+        }
+        int listSize = trelloBoard.getListCards(readerConfig.getTargetList()).size();
+        return listSize >= readerConfig.getMaxSize();
+    }
+}

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/reader/ReaderRoutes.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/reader/ReaderRoutes.java
@@ -12,8 +12,6 @@ import org.apache.camel.builder.RouteBuilder;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import static org.apache.camel.builder.Builder.bean;
-
 @ApplicationScoped
 public class ReaderRoutes
         extends RouteBuilder {

--- a/slushy-app/src/test/java/net/kemitix/slushy/app/reader/ReaderIsFullTest.java
+++ b/slushy-app/src/test/java/net/kemitix/slushy/app/reader/ReaderIsFullTest.java
@@ -1,0 +1,82 @@
+package net.kemitix.slushy.app.reader;
+
+import net.kemitix.slushy.app.SlushyCard;
+import net.kemitix.slushy.app.trello.TrelloBoard;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class ReaderIsFullTest
+        implements WithAssertions {
+
+    @Mock ReaderConfig readerConfig;
+    @Mock TrelloBoard trelloBoard;
+
+    @InjectMocks ReaderIsFull readerIsFull;
+
+    @Mock List<SlushyCard> targetList ;
+
+    @Test
+    public void ShouldNotBeFullWhenListSizeIsBelowMax() {
+        //given
+        givenMaxListSize(2);
+        givenListSize(1);
+        //when
+        boolean test = readerIsFull.test();
+        //then
+        assertThat(test).isFalse();
+    }
+
+    private void givenListSize(int listSize) {
+        String listName = "list-name";
+        given(readerConfig.getTargetList()).willReturn(listName);
+        given(trelloBoard.getListCards(listName)).willReturn(targetList);
+        given(targetList.size()).willReturn(listSize);
+    }
+
+    private void givenMaxListSize(int maxListSize) {
+        given(readerConfig.getMaxSize()).willReturn(maxListSize);
+    }
+
+    @Test
+    public void ShouldNotBeFullWhenMaxIsNegOne() {
+        //given
+        givenMaxListSize(-1);
+        //when
+        boolean test = readerIsFull.test();
+        //then
+        assertThat(test).isFalse();
+    }
+
+    @Test
+    public void ShouldBeFullWhenListSizeIsAtMax() {
+        //given
+        givenMaxListSize(2);
+        givenListSize(2);
+        //when
+        boolean test = readerIsFull.test();
+        //then
+        assertThat(test).isTrue();
+    }
+
+    @Test
+    public void ShouldBeFullWhenListSizeIsAboveMax() {
+        //given
+        givenMaxListSize(2);
+        givenListSize(3);
+        //when
+        boolean test = readerIsFull.test();
+        //then
+        assertThat(test).isTrue();
+    }
+}

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusReaderConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusReaderConfig.java
@@ -1,11 +1,17 @@
 package net.kemitix.slushy;
 
 import io.quarkus.arc.config.ConfigProperties;
+import lombok.Getter;
+import lombok.Setter;
 import net.kemitix.slushy.app.reader.ReaderConfig;
 
+@Setter
+@Getter
 @ConfigProperties(prefix = "slushy.reader")
 public class QuarkusReaderConfig
         extends AbstractQuarkusListProcessingConfig
         implements ReaderConfig {
+
+    private int maxSize;
 
 }

--- a/slushy/src/main/resources/application.properties
+++ b/slushy/src/main/resources/application.properties
@@ -43,9 +43,11 @@ slushy.reader.scan-period = 300000
 slushy.reader.source-list = Send to Reader
 slushy.reader.target-list = Slush
 slushy.reader.required-age-hours = 0
+slushy.reader.max-size = 1
 # retry every minute
 slushy.reader.retry-delay = 60000
 slushy.reader.routing-slip = \
+  direct:Slushy.Reader.LimitTargetSize,\
   direct:Slushy.CardToSubmission,\
   direct:Slushy.LoadAttachment,\
   direct:Slushy.FormatForReader,\


### PR DESCRIPTION
Set a parameter to control how many cards are allowed to be in the Slushpile list. As cards are removed, new cards can be added.