### PR TITLE
Fix conversion from RTF to HTML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy-root</artifactId>
     <packaging>pom</packaging>
-    <version>1.16.0</version>
+    <version>1.16.1</version>
 
     <modules>
         <module>slushy-parent</module>

--- a/slushy-api/pom.xml
+++ b/slushy-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.kemitix.slushy</groupId>
         <artifactId>slushy-parent</artifactId>
-        <version>1.16.0</version>
+        <version>1.16.1</version>
         <relativePath>../slushy-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/slushy-app/pom.xml
+++ b/slushy-app/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.kemitix.slushy</groupId>
         <artifactId>slushy-parent</artifactId>
-        <version>1.16.0</version>
+        <version>1.16.1</version>
         <relativePath>../slushy-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/fileconversion/MarkdownToHtmlConverter.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/fileconversion/MarkdownToHtmlConverter.java
@@ -43,8 +43,9 @@ public class MarkdownToHtmlConverter
             String markdown = Files.readString(sourceFile.toPath(), UTF_8);
             String html = String.format(
                     "<html><title></title><body>%s</body></html>",
-                    htmlCleaner.clean(
-                            renderer.render(parser.parse(markdown))));
+                    renderer.render(
+                            parser.parse(
+                                    htmlCleaner.clean(markdown))));
             Files.writeString(targetFile.toPath(), html);
             if (targetFile.exists()) {
                 return Optional.of(

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/fileconversion/RtfToHtmlAttachmentConverter.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/fileconversion/RtfToHtmlAttachmentConverter.java
@@ -37,7 +37,7 @@ public class RtfToHtmlAttachmentConverter
     ) {
         try {
             String rtfString = Files.readString(sourceFile.toPath());
-            String html = htmlCleaner.clean(converter.rtf2html(rtfString));
+            String html = converter.rtf2html(htmlCleaner.clean(rtfString));
             Files.writeString(targetFile.toPath(), html);
             if (targetFile.exists()) {
                 return Optional.of(

--- a/slushy-parent/pom.xml
+++ b/slushy-parent/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy-parent</artifactId>
-    <version>1.16.0</version>
+    <version>1.16.1</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/slushy/pom.xml
+++ b/slushy/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.kemitix.slushy</groupId>
   <artifactId>slushy</artifactId>
-  <version>1.16.0</version>
+  <version>1.16.1</version>
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>


### PR DESCRIPTION
HTML output has all HTML elements escaped. i.e. "`<html>`" is "`&lt;html&gt;`".