### PR TITLE
{hold,inbox}.*DueByRoute: fix typo

### DIFF
--- a/slushy-app/src/main/java/net/kemitix/slushy/app/hold/HoldDecisionDueByRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/hold/HoldDecisionDueByRoute.java
@@ -27,7 +27,7 @@ public class HoldDecisionDueByRoute
         from("direct:Slushy.Hold.DecisionDueBy")
                 .routeId("Slushy.Hold.DecisionDueBy")
                 .setHeader("SlushyDueInDays")
-                .constant(constant(holdConfig.getDueDays()))
+                .constant(holdConfig.getDueDays())
                 .bean(setDueInDays)
         ;
     }

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/inbox/InboxResponseDueByRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/inbox/InboxResponseDueByRoute.java
@@ -27,7 +27,7 @@ public class InboxResponseDueByRoute
         from("direct:Slushy.Inbox.ResponseDueBy")
                 .routeId("Slushy.Inbox.ResponseDueBy")
                 .setHeader("SlushyDueInDays")
-                .constant(constant(inboxConfig.getDueDays()))
+                .constant(inboxConfig.getDueDays())
                 .bean(setDueInDays)
         ;
     }


### PR DESCRIPTION
Remove extra `constant`.