### PR TITLE
Fix webhook parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy-root</artifactId>
     <packaging>pom</packaging>
-    <version>1.17.0</version>
+    <version>1.17.1</version>
 
     <modules>
         <module>slushy-parent</module>

--- a/slushy-api/pom.xml
+++ b/slushy-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.kemitix.slushy</groupId>
         <artifactId>slushy-parent</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.1</version>
         <relativePath>../slushy-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/slushy-app/pom.xml
+++ b/slushy-app/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.kemitix.slushy</groupId>
         <artifactId>slushy-parent</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.1</version>
         <relativePath>../slushy-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/trello/queue/WebHookTrelloRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/trello/queue/WebHookTrelloRoute.java
@@ -32,15 +32,25 @@ public class WebHookTrelloRoute
                 .setHeader("actionKey").jsonpath("body-json.action.display.translationKey")
                 .process(exchange ->
                         log.info(String.format("Action Key: %s", exchange.getIn().getHeader("ActionKey"))))
-                .end()
+
+                .endChoice()
         ;
 
         from("direct:Slushy.WebHook.Trello.MoveCard")
                 .routeId("Slushy.WebHook.Trello.MoveCard")
                 .setHeader("SlushyCardName").jsonpath("body-json.action.data.card.name")
+
+                .choice()
+
+                .when().jsonpath("body-json.action.data[?(@.listBefore empty false && @.listAfter empty false)]")
                 .setHeader("SlushyMovedFrom").jsonpath("body-json.action.data.listBefore.name")
                 .setHeader("SlushyMovedTo").jsonpath("body-json.action.data.listAfter.name")
                 .log("Moved Card '${header.SlushyCardName}' from '${header.SlushyMovedFrom}' to '${header.SlushyMovedTo}'")
+
+                .otherwise()
+                .log("Card moved, but listBefore and/or listAfter not given")
+
+                .endChoice()
         ;
     }
 }

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/trello/queue/WebHookTrelloRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/trello/queue/WebHookTrelloRoute.java
@@ -20,8 +20,8 @@ public class WebHookTrelloRoute
 
                 .log("WebHook message from Trello")
 
-//                .process(exchange ->
-//                        log.info(exchange.getIn().getBody(String.class)))
+                .process(exchange ->
+                        log.info(exchange.getIn().getBody(String.class)))
 
                 .choice()
 

--- a/slushy-parent/pom.xml
+++ b/slushy-parent/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy-parent</artifactId>
-    <version>1.17.0</version>
+    <version>1.17.1</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/slushy/pom.xml
+++ b/slushy/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.kemitix.slushy</groupId>
   <artifactId>slushy</artifactId>
-  <version>1.17.0</version>
+  <version>1.17.1</version>
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>


### PR DESCRIPTION
It appears that not all card move messages have a listBefore data element.

* Add logging of all message bodies recevied
* Test for presence of listBefore and listAfter elements before attempting to read their values