### PR TITLE
Prevent multiple threads from both acting on same card

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy-root</artifactId>
     <packaging>pom</packaging>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
 
     <modules>
         <module>slushy-parent</module>

--- a/slushy-api/pom.xml
+++ b/slushy-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.kemitix.slushy</groupId>
         <artifactId>slushy-parent</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <relativePath>../slushy-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/slushy-app/pom.xml
+++ b/slushy-app/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.kemitix.slushy</groupId>
         <artifactId>slushy-parent</artifactId>
-        <version>1.18.0</version>
+        <version>1.18.1</version>
         <relativePath>../slushy-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/reader/SendToReaderRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/reader/SendToReaderRoute.java
@@ -8,20 +8,25 @@ import org.apache.camel.builder.RouteBuilder;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import static org.apache.camel.support.processor.idempotent.MemoryIdempotentRepository.memoryIdempotentRepository;
+
 @ApplicationScoped
 public class SendToReaderRoute
         extends RouteBuilder {
     private final SlushyConfig slushyConfig;
+    private final ReaderConfig readerConfig;
     private final SendEmailAttachment sendEmailAttachment;
     private final AddComment addComment;
 
     @Inject
     public SendToReaderRoute(
             SlushyConfig slushyConfig,
+            ReaderConfig readerConfig,
             SendEmailAttachment sendEmailAttachment,
             AddComment addComment
     ) {
         this.slushyConfig = slushyConfig;
+        this.readerConfig = readerConfig;
         this.sendEmailAttachment = sendEmailAttachment;
         this.addComment = addComment;
     }
@@ -30,6 +35,11 @@ public class SendToReaderRoute
     public void configure() {
         from("direct:Slushy.SendToReader")
                 .routeId("Slushy.SendToReader")
+
+                .idempotentConsumer().simple("${header.SlushyCard.id}")
+                .skipDuplicate(true)
+                .messageIdRepository(() ->
+                        memoryIdempotentRepository(readerConfig.getMaxSize()))
 
                 .setHeader("SlushyRecipient").constant(slushyConfig.getReader())
                 .setHeader("SlushySender").constant(slushyConfig.getSender())

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/reader/SendToReaderRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/reader/SendToReaderRoute.java
@@ -31,13 +31,12 @@ public class SendToReaderRoute
         from("direct:Slushy.SendToReader")
                 .routeId("Slushy.SendToReader")
 
-                .setHeader("SlushyRecipient", slushyConfig::getReader)
-                .setHeader("SlushySender", slushyConfig::getSender)
-                .setHeader("SlushySubject", simple("Reader: ${header.SlushyCard.name}"))
+                .setHeader("SlushyRecipient").constant(slushyConfig.getReader())
+                .setHeader("SlushySender").constant(slushyConfig.getSender())
+                .setHeader("SlushySubject").simple("Reader: ${header.SlushyCard.name}")
                 .bean(sendEmailAttachment)
 
-                .setHeader("SlushyComment")
-                .constant("Sent attachment to reader")
+                .setHeader("SlushyComment").constant("Sent attachment to reader")
                 .bean(addComment)
         ;
     }

--- a/slushy-parent/pom.xml
+++ b/slushy-parent/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy-parent</artifactId>
-    <version>1.18.0</version>
+    <version>1.18.1</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/slushy/pom.xml
+++ b/slushy/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.kemitix.slushy</groupId>
   <artifactId>slushy</artifactId>
-  <version>1.18.0</version>
+  <version>1.18.1</version>
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>


### PR DESCRIPTION
Some actions triggered by webhook and by a timer are occasionally both running at the same time.

Adds idempotent consumer on email sending routes to prevent sending duplicate emails.