### PR TITLE
reader scan of list size should limit Trello API calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy-root</artifactId>
     <packaging>pom</packaging>
-    <version>1.18.2</version>
+    <version>1.18.3</version>
 
     <modules>
         <module>slushy-parent</module>

--- a/slushy-api/pom.xml
+++ b/slushy-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.kemitix.slushy</groupId>
         <artifactId>slushy-parent</artifactId>
-        <version>1.18.2</version>
+        <version>1.18.3</version>
         <relativePath>../slushy-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/slushy-app/pom.xml
+++ b/slushy-app/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.kemitix.slushy</groupId>
         <artifactId>slushy-parent</artifactId>
-        <version>1.18.2</version>
+        <version>1.18.3</version>
         <relativePath>../slushy-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/reader/LimitTargetSizeRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/reader/LimitTargetSizeRoute.java
@@ -19,7 +19,7 @@ public class LimitTargetSizeRoute
                 .routeId("Slushy.Reader.LimitTargetSize")
                 .choice()
                 .when()
-                .method(readerIsFull)
+                .method(readerIsFull, "test")
                 .process(exchange -> exchange.setRouteStop(true))
                 .end()
         ;

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/reader/ReaderIsFull.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/reader/ReaderIsFull.java
@@ -1,14 +1,26 @@
 package net.kemitix.slushy.app.reader;
 
+import lombok.extern.java.Log;
 import net.kemitix.slushy.app.trello.TrelloBoard;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAmount;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
+@Log
 @ApplicationScoped
 public class ReaderIsFull {
     private final ReaderConfig readerConfig;
     private final TrelloBoard trelloBoard;
+
+    private final AtomicInteger size = new AtomicInteger(0);
+    private final AtomicReference<Instant> updated = new AtomicReference<>(Instant.MIN);
+    private final TemporalAmount cachePeriod = Duration.of(1, ChronoUnit.MINUTES);
 
     @Inject
     public ReaderIsFull(ReaderConfig readerConfig, TrelloBoard trelloBoard) {
@@ -20,7 +32,21 @@ public class ReaderIsFull {
         if (readerConfig.getMaxSize() == -1){
             return false;
         }
-        int listSize = trelloBoard.getListCards(readerConfig.getTargetList()).size();
+        int listSize = getListSize();
         return listSize >= readerConfig.getMaxSize();
     }
+
+    void reset() {
+        updated.set(Instant.MIN);
+    }
+
+    private int getListSize() {
+        if (updated.get().plus(cachePeriod).isBefore(Instant.now())) {
+            size.set(trelloBoard.getListCards(readerConfig.getTargetList()).size());
+            log.info(String.format("Fetched trello list size: %d", size.get()));
+            updated.set(Instant.now());
+        }
+        return size.get();
+    }
+
 }

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/reader/ReaderMoveToTargetListRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/reader/ReaderMoveToTargetListRoute.java
@@ -12,14 +12,17 @@ public class ReaderMoveToTargetListRoute
 
     private final ReaderConfig readerConfig;
     private final MoveCard moveCard;
+    private final ReaderIsFull readerIsFull;
 
     @Inject
     public ReaderMoveToTargetListRoute(
             ReaderConfig readerConfig,
-            MoveCard moveCard
+            MoveCard moveCard,
+            ReaderIsFull readerIsFull
     ) {
         this.readerConfig = readerConfig;
         this.moveCard = moveCard;
+        this.readerIsFull = readerIsFull;
     }
 
     @Override
@@ -28,6 +31,7 @@ public class ReaderMoveToTargetListRoute
                 .routeId("Slushy.Reader.MoveToTargetList")
                 .setHeader("SlushyTargetList", readerConfig::getTargetList)
                 .bean(moveCard)
+                .bean(readerIsFull, "reset")
         ;
     }
 }

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/slush/CardMovedSlushListenerRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/slush/CardMovedSlushListenerRoute.java
@@ -1,6 +1,7 @@
 package net.kemitix.slushy.app.slush;
 
 import net.kemitix.slushy.app.reader.ReaderConfig;
+import net.kemitix.slushy.app.reader.ReaderIsFull;
 import org.apache.camel.builder.RouteBuilder;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -12,6 +13,7 @@ public class CardMovedSlushListenerRoute
         extends RouteBuilder {
 
     @Inject ReaderConfig readerConfig;
+    @Inject ReaderIsFull readerIsFull;
 
     @Override
     public void configure() throws Exception {
@@ -20,6 +22,7 @@ public class CardMovedSlushListenerRoute
                 .setHeader("ListSlush").constant(readerConfig.getTargetList())
                 .filter().simple("${header.SlushyMovedFrom} == ${header.ListSlush}")
                 .log("Card '${header.SlushyCardName}' removed from ${header.ListSlush}")
+                .bean(readerIsFull, "reset")
                 .to("direct:Slushy.Reader")
         ;
     }

--- a/slushy-parent/pom.xml
+++ b/slushy-parent/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy-parent</artifactId>
-    <version>1.18.2</version>
+    <version>1.18.3</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/slushy/pom.xml
+++ b/slushy/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.kemitix.slushy</groupId>
   <artifactId>slushy</artifactId>
-  <version>1.18.2</version>
+  <version>1.18.3</version>
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>


### PR DESCRIPTION
For every card in the reader source list, which can be in the hundreds, it is polling the Trello endpoint to get the list of cards in the reader target list. This is causing Trello to return an HTTP error code 429 - too many requests.

Need to either cache the result or, preferably, stop scanning the reader source list once we know that the target list is full.