### PR TITLE
Trello card moved message has unexpected json format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy-root</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.0</version>
+    <version>2.3.1</version>
 
     <modules>
         <module>slushy-parent</module>

--- a/slushy-api/pom.xml
+++ b/slushy-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.kemitix.slushy</groupId>
         <artifactId>slushy-parent</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1</version>
         <relativePath>../slushy-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/slushy-app/pom.xml
+++ b/slushy-app/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.kemitix.slushy</groupId>
         <artifactId>slushy-parent</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1</version>
         <relativePath>../slushy-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/trello/queue/PollQueueRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/trello/queue/PollQueueRoute.java
@@ -19,6 +19,12 @@ public class PollQueueRoute
                 System.getenv("AWS_REGION")
         ).toUpperCase();
 
+        errorHandler(deadLetterChannel("direct:dropInvalidPollQueueMessage"));
+
+        from("direct:dropInvalidPollQueueMessage")
+                .log("Dropping Invalid Poll queue message: ${body}")
+        ;
+
         fromF("aws-sqs://%s?region=%s&waitTimeSeconds=20&greedy=true",
                 queueName, region)
                 .routeId("Slushy.PollQueue")

--- a/slushy-parent/pom.xml
+++ b/slushy-parent/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy-parent</artifactId>
-    <version>2.3.0</version>
+    <version>2.3.1</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/slushy/pom.xml
+++ b/slushy/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.kemitix.slushy</groupId>
   <artifactId>slushy</artifactId>
-  <version>2.3.0</version>
+  <version>2.3.1</version>
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>


### PR DESCRIPTION
The logs are being flooded with the following message:
`org.apache.camel.ExpressionEvaluationException: com.jayway.jsonpath.PathNotFoundException: No results for path: $['body-json']['action']['data']['listBefore']`
