### PR TITLE
Multi-Submission false positive check when match against itself

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy-root</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
 
     <modules>
         <module>slushy-parent</module>

--- a/slushy-api/pom.xml
+++ b/slushy-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.kemitix.slushy</groupId>
         <artifactId>slushy-parent</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <relativePath>../slushy-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/slushy-app/pom.xml
+++ b/slushy-app/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.kemitix.slushy</groupId>
         <artifactId>slushy-parent</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <relativePath>../slushy-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/Submission.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/Submission.java
@@ -3,10 +3,12 @@ package net.kemitix.slushy.app;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.With;
 
 import java.time.Instant;
 
 @Getter
+@With
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Submission {
 

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/multisub/IsMultipleSubmission.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/multisub/IsMultipleSubmission.java
@@ -53,11 +53,13 @@ public class IsMultipleSubmission {
     ) {
         String email = submission.getEmail();
         String paypal = submission.getPaypal();
+        String submissionId = submission.getId();
         return (Submission other) ->
-                other.getEmail().equals(email) ||
-                        other.getEmail().equals(paypal) ||
-                        other.getPaypal().equals(email) ||
-                        other.getPaypal().equals(paypal);
+                !other.getId().equals(submissionId) &&
+                        (other.getEmail().equals(email) ||
+                                other.getEmail().equals(paypal) ||
+                                other.getPaypal().equals(email) ||
+                                other.getPaypal().equals(paypal));
     }
 
 }

--- a/slushy-app/src/test/java/net/kemitix/slushy/app/multisub/IsMultipleSubmissionTest.java
+++ b/slushy-app/src/test/java/net/kemitix/slushy/app/multisub/IsMultipleSubmissionTest.java
@@ -1,0 +1,157 @@
+package net.kemitix.slushy.app.multisub;
+
+import net.kemitix.slushy.app.Contract;
+import net.kemitix.slushy.app.ParseSubmission;
+import net.kemitix.slushy.app.Submission;
+import net.kemitix.slushy.app.WordLengthBand;
+import net.kemitix.trello.TrelloBoard;
+import net.kemitix.trello.TrelloCard;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class IsMultipleSubmissionTest
+        implements WithAssertions {
+
+
+    @Mock
+    MultiSubConfig config;
+
+    @Mock
+    ParseSubmission parser;
+
+    @Mock
+    TrelloBoard board;
+
+    @InjectMocks
+    IsMultipleSubmission sut = new IsMultipleSubmission();
+
+    Submission self = Submission.builder()
+            .id("selfId")
+            .title("selfTitle")
+            .byline("selfByLine")
+            .realName("selfReadName")
+            .email("selfEmail")
+            .paypal("selfPaypal")
+            .wordLength(WordLengthBand.LENGTH_LONG_SHORT)
+            .coverLetter("selfCoverLetter")
+            .contract(Contract.ORIGINAL)
+            .submittedDate(Instant.now())
+            .document("selfDocument")
+            ;
+    Submission other = Submission.builder()
+            .id("otherId")
+            .title("otherTitle")
+            .byline("otherByLine")
+            .realName("otherReadName")
+            .email("otherEmail")
+            .paypal("otherPaypal")
+            .wordLength(WordLengthBand.LENGTH_LONG_SHORT)
+            .coverLetter("otherCoverLetter")
+            .contract(Contract.ORIGINAL)
+            .submittedDate(Instant.now())
+            .document("otherDocument")
+            ;
+
+    Submission otherEmailToEmail = other.withEmail(self.getEmail());
+    Submission otherEmailToPaypal = other.withEmail(self.getPaypal());
+    Submission otherPaypalToEmail = other.withPaypal(self.getEmail());
+    Submission otherPaypalToPaypal = other.withPaypal(self.getPaypal());
+
+    @Mock
+    TrelloCard selfCard;
+
+    @Mock
+    TrelloCard otherCard;
+
+    List<TrelloCard> cardList = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        given(config.getLists()).willReturn("list");
+        given(board.getListCards("list")).willReturn(cardList);
+    }
+
+    @Test
+    void doesNotMatchSelf() {
+        //given
+        given(parser.parse(selfCard)).willReturn(self);
+        cardList.add(selfCard);
+        //when
+        RejectedMultipleSubmission result = sut.test(self);
+        //then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void doesNotMatchOther() {
+        //given
+        given(parser.parse(otherCard)).willReturn(other);
+        cardList.add(otherCard);
+        //when
+        RejectedMultipleSubmission result = sut.test(self);
+        //then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void matchesDuplicateByEmailToEmail() {
+        //given
+        given(parser.parse(otherCard)).willReturn(otherEmailToEmail);
+        cardList.add(otherCard);
+        //when
+        RejectedMultipleSubmission result = sut.test(self);
+        //then
+        assertThat(result.getCurrent()).isEqualTo(self);
+        assertThat(result.getExisting()).isEqualTo(otherEmailToEmail);
+    }
+
+    @Test
+    void matchesDuplicateByEmailToPaypal() {
+        //given
+        given(parser.parse(otherCard)).willReturn(otherEmailToPaypal);
+        cardList.add(otherCard);
+        //when
+        RejectedMultipleSubmission result = sut.test(self);
+        //then
+        assertThat(result.getCurrent()).isEqualTo(self);
+        assertThat(result.getExisting()).isEqualTo(otherEmailToPaypal);
+    }
+
+    @Test
+    void matchesDuplicateByPaypalToEmail() {
+        //given
+        given(parser.parse(otherCard)).willReturn(otherPaypalToEmail);
+        cardList.add(otherCard);
+        //when
+        RejectedMultipleSubmission result = sut.test(self);
+        //then
+        assertThat(result.getCurrent()).isEqualTo(self);
+        assertThat(result.getExisting()).isEqualTo(otherPaypalToEmail);
+    }
+
+    @Test
+    void matchesDuplicateByPaypalToPaypal() {
+        //given
+        given(parser.parse(otherCard)).willReturn(otherPaypalToPaypal);
+        cardList.add(otherCard);
+        //when
+        RejectedMultipleSubmission result = sut.test(self);
+        //then
+        assertThat(result.getCurrent()).isEqualTo(self);
+        assertThat(result.getExisting()).isEqualTo(otherPaypalToPaypal);
+    }
+
+}

--- a/slushy-parent/pom.xml
+++ b/slushy-parent/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy-parent</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/slushy/pom.xml
+++ b/slushy/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.kemitix.slushy</groupId>
   <artifactId>slushy</artifactId>
-  <version>2.3.1</version>
+  <version>2.3.2</version>
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>


### PR DESCRIPTION
Due to the multi-threaded nature of Apache Camel, a card can be handled both when a notification is received from Trello via the SQS queue and when a periodic timer triggers. In the rare case where these happen very close together, the Multi-Submission check can match a card against itself if the other thread has moved it into one of the lists it checks.

Fix: verify that any card matched against the current is not actually the same card