### PR TITLE
Handle legacy formsubmit.co email format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy-root</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.3</version>
+    <version>2.3.4</version>
 
     <modules>
         <module>slushy-parent</module>

--- a/slushy-api/pom.xml
+++ b/slushy-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.kemitix.slushy</groupId>
         <artifactId>slushy-parent</artifactId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
         <relativePath>../slushy-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/slushy-app/pom.xml
+++ b/slushy-app/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.kemitix.slushy</groupId>
         <artifactId>slushy-parent</artifactId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
         <relativePath>../slushy-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/ParseSubmission.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/ParseSubmission.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
 public class ParseSubmission {
 
     private static final Pattern HEADING =
-            Pattern.compile("^\\*\\*(?<heading>.*?):\\*\\*$",
+            Pattern.compile("^\\*{1,2}(?<heading>.*?):[\\*\\s]\\*$",
                     Pattern.MULTILINE);
 
     @Inject Now now;

--- a/slushy-app/src/test/java/net/kemitix/slushy/app/ParseSubmissionTest.java
+++ b/slushy-app/src/test/java/net/kemitix/slushy/app/ParseSubmissionTest.java
@@ -192,6 +192,143 @@ public class ParseSubmissionTest
     }
 
     @Nested
+    @DisplayName("Legacy Valid Submission")
+    // occasionally formsubmit.co will send an email with an old format
+    public class LegacyValidSubmissionTests {
+
+        Card card;
+        URL validResource = this.getClass().getResource("legacy-valid-submission.txt");
+        String documentUrl = "document.docx";
+
+        @BeforeEach
+        public void setUp() throws URISyntaxException, IOException {
+            card = new Card();
+            String validCardDescription =
+                    String.join("\n",
+                            Files.readAllLines(Paths.get(validResource.toURI())));
+            card.setDesc(validCardDescription);
+            given(trelloBoard.getAttachments(card))
+                    .willReturn(List.of(new Attachment(documentUrl)));
+        }
+
+        @Test
+        @DisplayName("Parse Story Title")
+        public void parseStoryTitle() {
+            assertThat(parseSubmission.parse(card).getTitle())
+                    .isEqualTo("TEST Story Title");
+        }
+
+        @Test
+        @DisplayName("Parse Byline")
+        public void parseByline() {
+            assertThat(parseSubmission.parse(card).getByline())
+                    .isEqualTo("TEST Author ByLine");
+        }
+
+        @Test
+        @DisplayName("Parse Real Name")
+        public void parseRealName() {
+            assertThat(parseSubmission.parse(card).getRealName())
+                    .isEqualTo("TEST Author Name");
+        }
+
+        @Test
+        @DisplayName("Parse Email")
+        public void parseEmail() {
+            assertThat(parseSubmission.parse(card).getEmail())
+                    .isEqualTo("my_email@example.com");
+        }
+
+        @Test
+        @DisplayName("Parse Paypal")
+        public void parsePaypal() {
+            assertThat(parseSubmission.parse(card).getPaypal())
+                    .isEqualTo("paypal@example.com");
+        }
+
+        @Test
+        @DisplayName("Parse Word Length")
+        public void parseWordLength() {
+            assertThat(parseSubmission.parse(card).getWordLengthBand())
+                    .isEqualTo(WordLengthBand.LENGTH_SHORT_SHORT);
+        }
+
+        @Test
+        @DisplayName("Parse Cover Letter")
+        public void parseCoverLetter() {
+            assertThat(parseSubmission.parse(card).getCoverLetter())
+                    .isEqualTo("TEST Cover Letter\n\nMore info.");
+        }
+
+        @Test
+        @DisplayName("Parse Contract")
+        public void parseContract() {
+            assertThat(parseSubmission.parse(card).getContract())
+                    .isEqualTo(Contract.ORIGINAL);
+        }
+
+        @Test
+        @DisplayName("Parse Submitted Date")
+        public void parseSubmittedDate() {
+            assertThat(parseSubmission.parse(card).getDate())
+                    .isEqualTo(Instant.ofEpochSecond(123456789));
+        }
+
+        @Test
+        @DisplayName("Attachment")
+        public void attachment() {
+            assertThat(parseSubmission.parse(card).getDocument())
+                    .isEqualTo(documentUrl);
+        }
+
+        // Kindle Personal Documents Service:
+        // https://www.amazon.co.uk/gp/help/customer/display.html?nodeId=200767340
+        //        Kindle Format (.MOBI, .AZW)
+        //        Microsoft Word (.DOC, .DOCX)
+        //        HTML (.HTML, .HTM)
+        //        Text (.TXT)
+        // The following types claim to be supported by Kindle, but aren't
+        //        RTF (.RTF)
+        //        PDF (.PDF)
+        // The following types are supported by Kindle, but we don't want them
+        //        JPEG (.JPEG, .JPG)
+        //        GIF (.GIF)
+        //        PNG (.PNG)
+        //        BMP (.BMP)
+        @ParameterizedTest
+        @DisplayName("Accepts Kindle supported types")
+        @ValueSource(strings = {"MOBI", "AZW", "DOC", "DOCX", "HTML", "HTM", "TXT"})
+        public void acceptsKindleTypes(String type) {
+            documentUrl = "document." + type;
+            given(trelloBoard.getAttachments(card))
+                    .willReturn(List.of(new Attachment(documentUrl)));
+            assertThat(parseSubmission.parse(card).getDocument())
+                    .isEqualTo(documentUrl);
+        }
+
+        @ParameterizedTest
+        @DisplayName("Accepts convertible types")
+        @ValueSource(strings = {"ODT", "RTF"})
+        public void acceptsConvertibleTypes(String type) {
+            documentUrl = "document." + type;
+            given(trelloBoard.getAttachments(card))
+                    .willReturn(List.of(new Attachment(documentUrl)));
+            assertThat(parseSubmission.parse(card).getDocument())
+                    .isEqualTo(documentUrl);
+        }
+
+        @Test
+        @DisplayName("Reject invalid file type")
+        public void rejectInvalidType() {
+            documentUrl = "document.JPG";
+            given(trelloBoard.getAttachments(card))
+                    .willReturn(List.of(new Attachment(documentUrl)));
+            assertThat(parseSubmission.parse(card).getDocument())
+                    .isNull();
+        }
+    }
+
+    @Nested
     @DisplayName("Invalid Submission")
     public class InvalidSubmissionTests {
         //TODO

--- a/slushy-app/src/test/resources/net/kemitix/slushy/app/legacy-valid-submission.txt
+++ b/slushy-app/src/test/resources/net/kemitix/slushy/app/legacy-valid-submission.txt
@@ -1,0 +1,51 @@
+Someone just submitted your form on https://www.cossmass.com/submit/.
+
+Here's what they had to say:
+
+*storytitle: *
+
+TEST Story Title
+
+*wordcount: *
+
+short-short
+
+*contract: *
+
+original
+
+*name: *
+
+TEST Author Name
+
+*byline: *
+
+TEST Author ByLine
+
+*email: *
+
+my\_email@example.com
+
+*paypal: *
+
+paypal@example.com
+
+*responsetime: *
+
+3 months
+
+*coverletter: *
+
+TEST Cover Letter
+
+More info.
+
+*upload: *
+
+Abigail.docx
+
+Submitted Fri, Jan 10, 2020 7:32 PM
+
+Your friends from,
+
+[**FormSubmit Team**](https://formsubmit.co)

--- a/slushy-parent/pom.xml
+++ b/slushy-parent/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy-parent</artifactId>
-    <version>2.3.3</version>
+    <version>2.3.4</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/slushy/pom.xml
+++ b/slushy/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.kemitix.slushy</groupId>
   <artifactId>slushy</artifactId>
-  <version>2.3.3</version>
+  <version>2.3.4</version>
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>


### PR DESCRIPTION
For some reason formsubmit.co will occasionally send form submissions using a format they generally stopped using about a year ago. Handle both the current and the old format.

i.e. labels are currently `**heading:**`, while the legacy format is `*heading: *`