### PR TITLE
Update Dockerfile to work with latest Quarkus generated app

### DIFF
--- a/slushy/src/main/docker/Dockerfile
+++ b/slushy/src/main/docker/Dockerfile
@@ -38,8 +38,7 @@ RUN wget -nv -O- \
 
 WORKDIR /app
 
-COPY target/lib /app/lib/
-COPY target/slushy-runner.jar /app/
+COPY target/quarkus-app/ /app/
 
 EXPOSE 8080
-CMD ["java", "-jar", "/app/slushy-runner.jar"]
+CMD ["java", "-jar", "/app/quarkus-run.jar"]


### PR DESCRIPTION
A recent upgrade to Quarkus changed the layout of the output written to `target/`. The existing `Dockerfile` no longer copies all the required files.