### PR TITLE
Insert formatted summary on first parse of card

### DIFF
--- a/slushy-app/src/main/java/net/kemitix/slushy/app/inbox/ReformatCard.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/inbox/ReformatCard.java
@@ -13,6 +13,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.Date;
 
 @ApplicationScoped
@@ -47,10 +48,42 @@ public class ReformatCard {
         card.setDue(new Date(now.get()
                 .plus(inboxConfig.getDueDays(), ChronoUnit.DAYS)
                 .atZone(ZoneOffset.ofHours(0)).toEpochSecond() * 1000));
+        // Description/Body
+        if (hasNoSummary(card)) {
+            insertSummary(submission, card);
+        }
         // Save
         trelloBoard.updateCard(card);
 
         return submission;
+    }
+
+    private boolean hasNoSummary(TrelloCard card) {
+        return !Arrays.asList(card.getDesc().split("\n"))
+                .contains("# Original");
+    }
+
+    private void insertSummary(Submission submission, TrelloCard card) {
+        String summary = String.format("> %s\n" +
+                        "\n" +
+                        "%s / %s\n" +
+                        "> %s\n" +
+                        "\n" +
+                        "- email: %s\n" +
+                        "- contract name: %s\n" +
+                        "- paypal: %s\n" +
+                        "\n" +
+                        "---\n" +
+                        "# Original\n",
+                submission.getLogLine(),
+                submission.getWordLengthBand().toString(),
+                submission.getGenre().toString(),
+                submission.getCoverLetter(),
+                submission.getEmail(),
+                submission.getRealName(),
+                submission.getPaypal()
+        );
+        card.setDesc(summary + card.getDesc());
     }
 
 }

--- a/slushy-app/src/test/java/net/kemitix/slushy/app/inbox/ReformatCardTest.java
+++ b/slushy-app/src/test/java/net/kemitix/slushy/app/inbox/ReformatCardTest.java
@@ -41,6 +41,7 @@ public class ReformatCardTest
         given(now.get()).willReturn(Instant.ofEpochSecond(1234567890));
         given(submission.getTitle()).willReturn(storyTitle);
         given(submission.getByline()).willReturn(authorByline);
+        given(card.getDesc()).willReturn("");
     }
 
     @Test

--- a/slushy-app/src/test/java/net/kemitix/slushy/app/inbox/ReformatCardTest.java
+++ b/slushy-app/src/test/java/net/kemitix/slushy/app/inbox/ReformatCardTest.java
@@ -1,6 +1,8 @@
 package net.kemitix.slushy.app.inbox;
 
+import net.kemitix.slushy.app.Genre;
 import net.kemitix.slushy.app.Now;
+import net.kemitix.slushy.app.WordLengthBand;
 import net.kemitix.trello.TrelloCard;
 import net.kemitix.slushy.app.Submission;
 import net.kemitix.trello.TrelloBoard;
@@ -41,6 +43,8 @@ public class ReformatCardTest
         given(now.get()).willReturn(Instant.ofEpochSecond(1234567890));
         given(submission.getTitle()).willReturn(storyTitle);
         given(submission.getByline()).willReturn(authorByline);
+        given(submission.getWordLengthBand()).willReturn(WordLengthBand.LENGTH_LONG_SHORT);
+        given(submission.getGenre()).willReturn(Genre.Fantasy);
         given(card.getDesc()).willReturn("");
     }
 


### PR DESCRIPTION
Inserted at the start of the card description in a format that won't interfere with card parsers.