### PR TITLE
Report status via a card

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Define the following environment variables to configure Slushy:
 * `SLUSHY_USER` - the Trello User name
 * `SLUSHY_READER` - the email to send attachements to
 * `SLUSHY_SENDER` - the email to send emails from and to receive cc'd copies
+* `SLUSHY_STATUS_LIST` - the Trello List to report the status into
+* `SLUSHY_STATUS_CARD` - the Trello Card to report the status into
 
 # Structure/Dependencies
 

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/status/StatusConfig.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/status/StatusConfig.java
@@ -2,6 +2,19 @@ package net.kemitix.slushy.app.status;
 
 public interface StatusConfig {
 
+    /**
+     * How often to report the status in seconds.
+     */
     int getLogPeriod();
+
+    /**
+     * The name of the List to report the status to.
+     */
+    String getListName();
+
+    /**
+     * The name of the Card to report the status to.
+     */
+    String getCardName();
 
 }

--- a/slushy.sh
+++ b/slushy.sh
@@ -12,6 +12,8 @@ docker run -d \
        -e SLUSHY_READER \
        -e SLUSHY_WEBHOOK \
        -e SLUSHY_QUEUE \
+       -e SLUSHY_STATUS_LIST \
+       -e SLUSHY_STATUS_CARD \
        -e AWS_ACCESS_KEY \
        -e AWS_SECRET_KEY \
        -e AWS_REGION \

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusStatusConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusStatusConfig.java
@@ -12,5 +12,7 @@ public class QuarkusStatusConfig
         implements StatusConfig {
 
     private int logPeriod;
+    private String listName = System.getenv("SLUSHY_STATUS_LIST");
+    private String cardName = System.getenv("SLUSHY_STATUS_CARD");
 
 }

--- a/slushy/src/main/resources/application.properties
+++ b/slushy/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 # Configuration file
 # key = value
 
-# every 5 minutes
-slushy.status.log-period=300000
+# every 1 minutes
+slushy.status.log-period=60000
 
 # Email
 # scan period: 5 minutes - max time to try sending an email


### PR DESCRIPTION
The environment variables specify a card and list to be updated with a status report.

- At startup use environment variables `SLUSHY_STATUS_LIST` and `SLUSHY_STATUS_CARD` to identify a card on the board to be used to report status reports