### PR TITLE
Dynamically load some configuration from a card

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Define the following environment variables to configure Slushy:
 * `SLUSHY_USER` - the Trello User name
 * `SLUSHY_READER` - the email to send attachements to
 * `SLUSHY_SENDER` - the email to send emails from and to receive cc'd copies
+* `SLUSHY_CONFIG_LIST` - the Trello List to read the additional config from
+* `SLUSHY_CONFIG_CARD` - the Trello Card to read the additional config from
 * `SLUSHY_STATUS_LIST` - the Trello List to report the status into
 * `SLUSHY_STATUS_CARD` - the Trello Card to report the status into
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy-root</artifactId>
     <packaging>pom</packaging>
-    <version>2.4.0</version>
+    <version>2.5.0</version>
 
     <modules>
         <module>slushy-parent</module>

--- a/slushy-api/pom.xml
+++ b/slushy-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.kemitix.slushy</groupId>
         <artifactId>slushy-parent</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
         <relativePath>../slushy-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/slushy-api/src/main/java/net/kemitix/slushy/QuarkusDynamicConfigConfig.java
+++ b/slushy-api/src/main/java/net/kemitix/slushy/QuarkusDynamicConfigConfig.java
@@ -1,0 +1,16 @@
+package net.kemitix.slushy;
+
+import lombok.Getter;
+import net.kemitix.slushy.app.config.DynamicConfigConfig;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@Getter
+@ApplicationScoped
+public class QuarkusDynamicConfigConfig
+        implements DynamicConfigConfig {
+
+    private final String listName = System.getenv("SLUSHY_CONFIG_LIST");
+    private final String cardName = System.getenv("SLUSHY_CONFIG_CARD");
+
+}

--- a/slushy-app/pom.xml
+++ b/slushy-app/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.kemitix.slushy</groupId>
         <artifactId>slushy-parent</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
         <relativePath>../slushy-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/CardIdentifierConfig.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/CardIdentifierConfig.java
@@ -1,0 +1,10 @@
+package net.kemitix.slushy.app;
+
+public interface CardIdentifierConfig {
+
+    /**
+     * The name of the Card to report the status to.
+     */
+    String getCardName();
+
+}

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/DueDays.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/DueDays.java
@@ -4,5 +4,5 @@ public interface DueDays {
     /**
      * How long before a still-waiting-to-be-read response should be sent.
      */
-    Long getDueDays();
+    long getDueDays();
 }

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/DueDays.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/DueDays.java
@@ -4,5 +4,5 @@ public interface DueDays {
     /**
      * How long before a still-waiting-to-be-read response should be sent.
      */
-    long getDueDays();
+    Long getDueDays();
 }

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/ListIdentifierConfig.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/ListIdentifierConfig.java
@@ -1,0 +1,10 @@
+package net.kemitix.slushy.app;
+
+public interface ListIdentifierConfig {
+
+    /**
+     * The name of the List to report the status to.
+     */
+    String getListName();
+
+}

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/config/AbstractDynamicConfig.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/config/AbstractDynamicConfig.java
@@ -1,41 +1,28 @@
 package net.kemitix.slushy.app.config;
 
-import lombok.extern.java.Log;
-
+import java.util.Optional;
 import java.util.Properties;
-import java.util.function.Consumer;
-import java.util.function.Function;
 
-@Log
 public abstract class AbstractDynamicConfig
         implements DynamicConfig {
 
-    @Override
-    public void update(Properties properties) {
-        // do nothing
-    }
-
-    protected <T> void update(
-            String key,
-            Function<String, T> parser,
-            Consumer<T> setter,
-            Properties properties
-    ) {
-        String property = getConfigPrefix() + "." + key;
-        if (properties.containsKey(property)) {
-            T value = parser.apply((String) properties.get(property));
-            log.info(String.format("Update %s to %s", property, value));
-            setter.accept(value);
+    protected Optional<String> findValue(String name) {
+        String key = getConfigPrefix() + "." + name;
+        Properties properties = DynamicProperties.INSTANCE.getProperties();
+        if (properties.containsKey(key)) {
+            return Optional.ofNullable(properties.getProperty(key));
         }
+        return Optional.empty();
     }
 
-    protected void update(
-            String key,
-            Consumer<String> setter,
-            Properties properties
-    ) {
-        update(key, Function.identity(), setter, properties);
+    protected Optional<Long> findLongValue(String name) {
+        return findValue(name)
+                .map(Long::parseLong);
     }
 
+    protected Optional<Integer> findIntegerValue(String name) {
+        return findValue(name)
+                .map(Integer::parseInt);
+    }
 
 }

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/config/AbstractDynamicConfig.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/config/AbstractDynamicConfig.java
@@ -1,0 +1,41 @@
+package net.kemitix.slushy.app.config;
+
+import lombok.extern.java.Log;
+
+import java.util.Properties;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+@Log
+public abstract class AbstractDynamicConfig
+        implements DynamicConfig {
+
+    @Override
+    public void update(Properties properties) {
+        // do nothing
+    }
+
+    protected <T> void update(
+            String key,
+            Function<String, T> parser,
+            Consumer<T> setter,
+            Properties properties
+    ) {
+        String property = getConfigPrefix() + "." + key;
+        if (properties.containsKey(property)) {
+            T value = parser.apply((String) properties.get(property));
+            log.info(String.format("Update %s to %s", property, value));
+            setter.accept(value);
+        }
+    }
+
+    protected void update(
+            String key,
+            Consumer<String> setter,
+            Properties properties
+    ) {
+        update(key, Function.identity(), setter, properties);
+    }
+
+
+}

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/config/DynamicConfig.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/config/DynamicConfig.java
@@ -1,13 +1,7 @@
 package net.kemitix.slushy.app.config;
 
-import java.util.Properties;
-import java.util.function.Consumer;
-import java.util.function.Function;
-
 public interface DynamicConfig {
 
     String getConfigPrefix();
-
-    void update(Properties properties);
 
 }

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/config/DynamicConfig.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/config/DynamicConfig.java
@@ -1,0 +1,13 @@
+package net.kemitix.slushy.app.config;
+
+import java.util.Properties;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public interface DynamicConfig {
+
+    String getConfigPrefix();
+
+    void update(Properties properties);
+
+}

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/config/DynamicConfigConfig.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/config/DynamicConfigConfig.java
@@ -1,14 +1,8 @@
-package net.kemitix.slushy.app.status;
+package net.kemitix.slushy.app.config;
 
 import net.kemitix.slushy.app.CardIdentifierConfig;
 import net.kemitix.slushy.app.ListIdentifierConfig;
 
-public interface StatusConfig
+public interface DynamicConfigConfig
         extends ListIdentifierConfig, CardIdentifierConfig {
-
-    /**
-     * How often to report the status in seconds.
-     */
-    int getLogPeriod();
-
 }

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/config/DynamicProperties.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/config/DynamicProperties.java
@@ -1,0 +1,16 @@
+package net.kemitix.slushy.app.config;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Properties;
+
+@Setter
+@Getter
+public class DynamicProperties {
+
+    public static final DynamicProperties INSTANCE = new DynamicProperties();
+
+    private final Properties properties = new Properties();
+
+}

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/config/LoadDynamicConfig.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/config/LoadDynamicConfig.java
@@ -2,6 +2,7 @@ package net.kemitix.slushy.app.config;
 
 import com.amazonaws.util.StringInputStream;
 import lombok.SneakyThrows;
+import lombok.extern.java.Log;
 import net.kemitix.trello.TrelloBoard;
 import net.kemitix.trello.TrelloCard;
 
@@ -12,6 +13,7 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.Properties;
 
+@Log
 @ApplicationScoped
 public class LoadDynamicConfig {
 
@@ -20,6 +22,7 @@ public class LoadDynamicConfig {
     @Inject Instance<DynamicConfig> dynamicConfigs;
 
     public void load() {
+        log.info("Detected Config Card update");
         findConfigProperties()
                 .ifPresent(properties -> {
                     dynamicConfigs.stream()

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/config/LoadDynamicConfig.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/config/LoadDynamicConfig.java
@@ -1,0 +1,55 @@
+package net.kemitix.slushy.app.config;
+
+import com.amazonaws.util.StringInputStream;
+import lombok.SneakyThrows;
+import net.kemitix.trello.TrelloBoard;
+import net.kemitix.trello.TrelloCard;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Properties;
+
+@ApplicationScoped
+public class LoadDynamicConfig {
+
+    @Inject DynamicConfigConfig config;
+    @Inject TrelloBoard trelloBoard;
+    @Inject Instance<DynamicConfig> dynamicConfigs;
+
+    public void load() {
+        findConfigProperties()
+                .ifPresent(properties -> {
+                    dynamicConfigs.stream()
+                            .forEach(dynamicConfig -> {
+                                dynamicConfig.update(properties);
+                            });
+                });
+    }
+
+    private Optional<Properties> findConfigProperties() {
+        return findConfigCard()
+                .map(TrelloCard::getDesc)
+                .map(this::parseConfigCardDesc);
+    }
+
+    private Optional<TrelloCard> findConfigCard() {
+        return Optional.ofNullable(config.getListName())
+                .map(trelloBoard::getListCards)
+                .stream()
+                .flatMap(Collection::stream)
+                .filter(card -> config.getCardName().equals(card.getName()))
+                .findFirst();
+    }
+
+    @SneakyThrows
+    private Properties parseConfigCardDesc(String desc) {
+        Properties properties = new Properties();
+        StringInputStream inStream = new StringInputStream(desc);
+        properties.load(inStream);
+        return properties;
+    }
+
+}

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/config/LoadDynamicConfig.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/config/LoadDynamicConfig.java
@@ -17,6 +17,9 @@ import java.util.Properties;
 @ApplicationScoped
 public class LoadDynamicConfig {
 
+    private final DynamicProperties dynamicProperties =
+            DynamicProperties.INSTANCE;
+
     @Inject DynamicConfigConfig config;
     @Inject TrelloBoard trelloBoard;
     @Inject Instance<DynamicConfig> dynamicConfigs;
@@ -24,12 +27,13 @@ public class LoadDynamicConfig {
     public void load() {
         log.info("Detected Config Card update");
         findConfigProperties()
-                .ifPresent(properties -> {
-                    dynamicConfigs.stream()
-                            .forEach(dynamicConfig -> {
-                                dynamicConfig.update(properties);
-                            });
-                });
+//                .ifPresent(properties -> {
+//                    dynamicConfigs.stream()
+//                            .forEach(dynamicConfig -> {
+//                                dynamicConfig.update(properties);
+//                            });
+//                });
+        ;
     }
 
     private Optional<Properties> findConfigProperties() {
@@ -49,9 +53,11 @@ public class LoadDynamicConfig {
 
     @SneakyThrows
     private Properties parseConfigCardDesc(String desc) {
-        Properties properties = new Properties();
         StringInputStream inStream = new StringInputStream(desc);
+        Properties properties = dynamicProperties.getProperties();
+        properties.clear();
         properties.load(inStream);
+        log.info("Loaded properties: " + properties);
         return properties;
     }
 

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/config/LoadInitialDynamicConfigRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/config/LoadInitialDynamicConfigRoute.java
@@ -15,6 +15,11 @@ public class LoadInitialDynamicConfigRoute
     public void configure() throws Exception {
         from("timer:load-initial-dynamic-config?repeatCount=1")
                 .routeId("load-initial-dynamic-config")
+                .to("direct:Slushy.Dynamic.Config.Update")
+        ;
+
+        from("direct:Slushy.Dynamic.Config.Update")
+                .routeId("Slushy.Dynamic.Config.Update")
                 .bean(loadDynamicConfig)
         ;
     }

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/config/LoadInitialDynamicConfigRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/config/LoadInitialDynamicConfigRoute.java
@@ -1,0 +1,21 @@
+package net.kemitix.slushy.app.config;
+
+import org.apache.camel.builder.RouteBuilder;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class LoadInitialDynamicConfigRoute
+        extends RouteBuilder {
+
+    @Inject LoadDynamicConfig loadDynamicConfig;
+
+    @Override
+    public void configure() throws Exception {
+        from("timer:load-initial-dynamic-config?repeatCount=1")
+                .routeId("load-initial-dynamic-config")
+                .bean(loadDynamicConfig)
+        ;
+    }
+}

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/email/SendEmailRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/email/SendEmailRoute.java
@@ -35,7 +35,7 @@ public class SendEmailRoute
                 .messageIdRepository(MemoryIdempotentRepository::new)
 
                 .setHeader("SlushyRecipient").simple("${header.SlushySubmission.email}")
-                .setHeader("SlushySender").constant(trelloConfig.getSender())
+                .setHeader("SlushySender", trelloConfig::getSender)
                 .toD("velocity:net/kemitix/slushy/app/${header.SlushyEmailTemplate}/subject.txt")
                 .setHeader("SlushySubject").body()
                 .toD("velocity:net/kemitix/slushy/app/${header.SlushyEmailTemplate}/body.txt")

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/hold/HoldDecisionDueByRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/hold/HoldDecisionDueByRoute.java
@@ -26,8 +26,7 @@ public class HoldDecisionDueByRoute
     public void configure() {
         from("direct:Slushy.Hold.DecisionDueBy")
                 .routeId("Slushy.Hold.DecisionDueBy")
-                .setHeader("SlushyDueInDays")
-                .constant(holdConfig.getDueDays())
+                .setHeader("SlushyDueInDays", holdConfig::getDueDays)
                 .bean(setDueInDays)
         ;
     }

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/inbox/InboxConfig.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/inbox/InboxConfig.java
@@ -2,6 +2,9 @@ package net.kemitix.slushy.app.inbox;
 
 import net.kemitix.slushy.app.DueDays;
 import net.kemitix.slushy.app.ListProcessConfig;
+import net.kemitix.slushy.app.config.DynamicConfigConfig;
+
+import javax.inject.Inject;
 
 public interface InboxConfig
         extends ListProcessConfig, DueDays {

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/inbox/InboxMoveToTargetListRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/inbox/InboxMoveToTargetListRoute.java
@@ -1,11 +1,15 @@
 package net.kemitix.slushy.app.inbox;
 
+import lombok.Getter;
+import lombok.extern.java.Log;
 import net.kemitix.slushy.app.MoveCard;
 import org.apache.camel.builder.RouteBuilder;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import java.util.function.Supplier;
 
+@Log
 @ApplicationScoped
 public class InboxMoveToTargetListRoute
         extends RouteBuilder {
@@ -26,8 +30,16 @@ public class InboxMoveToTargetListRoute
     public void configure() {
         from("direct:Slushy.Inbox.MoveToTargetList")
                 .routeId("Slushy.Inbox.MoveToTargetList")
-                .setHeader("SlushyTargetList", inboxConfig::getTargetList)
+                .setHeader("SlushyTargetList", getGetTargetList())
                 .bean(moveCard)
         ;
+    }
+
+    private Supplier<Object> getGetTargetList() {
+        return () -> {
+            String targetList = inboxConfig.getTargetList();
+            log.info("GetTargetList = " + targetList);
+            return targetList;
+        };
     }
 }

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/inbox/InboxResponseDueByRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/inbox/InboxResponseDueByRoute.java
@@ -26,8 +26,7 @@ public class InboxResponseDueByRoute
     public void configure() {
         from("direct:Slushy.Inbox.ResponseDueBy")
                 .routeId("Slushy.Inbox.ResponseDueBy")
-                .setHeader("SlushyDueInDays")
-                .constant(inboxConfig.getDueDays())
+                .setHeader("SlushyDueInDays", inboxConfig::getDueDays)
                 .bean(setDueInDays)
         ;
     }

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/inbox/InboxSendEmailRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/inbox/InboxSendEmailRoute.java
@@ -8,7 +8,6 @@ import org.apache.camel.Predicate;
 import org.apache.camel.builder.RouteBuilder;
 
 import javax.enterprise.context.ApplicationScoped;
-import java.util.List;
 
 @ApplicationScoped
 public class InboxSendEmailRoute

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/inbox/InboxTimerRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/inbox/InboxTimerRoute.java
@@ -6,6 +6,7 @@ import org.apache.camel.builder.RouteBuilder;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import java.util.function.Function;
 
 @ApplicationScoped
 public class InboxTimerRoute
@@ -30,7 +31,7 @@ public class InboxTimerRoute
         fromF("timer:inbox?period=%s", inboxConfig.getScanPeriod())
                 .routeId("Slushy.Inbox")
 
-                .setHeader("ListName").constant(inboxConfig.getSourceList())
+                .setHeader("ListName", inboxConfig::getSourceList)
                 .setBody().method(loadList)
                 .split(body())
 

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/reader/CardMovedReaderListenerRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/reader/CardMovedReaderListenerRoute.java
@@ -16,7 +16,7 @@ public class CardMovedReaderListenerRoute
     public void configure() throws Exception {
         from("seda:Slushy.WebHook.CardMoved?multipleConsumers=true")
                 .routeId("Slushy.WebHook.CardMoved.Reader")
-                .setHeader("ListName").constant(readerConfig.getSourceList())
+                .setHeader("ListName", readerConfig::getSourceList)
                 .filter().simple("${header.SlushyMovedTo} == ${header.ListName}")
                 .log("Card '${header.SlushyCardName}' added to ${header.ListName}")
                 .to("direct:Slushy.Reader")

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/reader/ReaderRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/reader/ReaderRoute.java
@@ -21,7 +21,7 @@ public class ReaderRoute
 
                 .throttle(1).timePeriodMillis(TWENTY_SECONDS)
 
-                .setHeader("ListName").constant(readerConfig.getSourceList())
+                .setHeader("ListName", readerConfig::getSourceList)
                 .setBody().method(loadList)
                 .split(body())
                 .setHeader("SlushyRoutingSlip", readerConfig::getRoutingSlip)

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/reader/SendToReaderRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/reader/SendToReaderRoute.java
@@ -41,8 +41,8 @@ public class SendToReaderRoute
                 .messageIdRepository(() ->
                         memoryIdempotentRepository(readerConfig.getMaxSize()))
 
-                .setHeader("SlushyRecipient").constant(trelloConfig.getReader())
-                .setHeader("SlushySender").constant(trelloConfig.getSender())
+                .setHeader("SlushyRecipient", trelloConfig::getReader)
+                .setHeader("SlushySender", trelloConfig::getSender)
                 .setHeader("SlushySubject").simple("Reader: ${header.SlushyCard.name}")
                 .bean(sendEmailAttachment)
 

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/slush/CardMovedSlushListenerRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/slush/CardMovedSlushListenerRoute.java
@@ -19,7 +19,7 @@ public class CardMovedSlushListenerRoute
     public void configure() throws Exception {
         from("seda:Slushy.WebHook.CardMoved?multipleConsumers=true")
                 .routeId("Slushy.WebHook.CardMoved.Slush")
-                .setHeader("ListSlush").constant(readerConfig.getTargetList())
+                .setHeader("ListSlush", readerConfig::getTargetList)
                 .filter().simple("${header.SlushyMovedFrom} == ${header.ListSlush}")
                 .log("Card '${header.SlushyCardName}' removed from ${header.ListSlush}")
                 .bean(readerIsFull, "reset")

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/trello/queue/WebHookTrelloRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/trello/queue/WebHookTrelloRoute.java
@@ -70,8 +70,8 @@ public class WebHookTrelloRoute
                 .to("direct:Slushy.WebHook.Trello.ActionMoveCardFromListToList")
                 .endChoice()
 
-                .otherwise()
-                .log("Ignoring: ${header.ActionType} / ${header.TranslationKey}")
+                //.otherwise()
+                //.log("Ignoring: ${header.ActionType} / ${header.TranslationKey}")
 
                 .end()
         ;

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/trello/queue/WebHookTrelloRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/trello/queue/WebHookTrelloRoute.java
@@ -88,7 +88,7 @@ public class WebHookTrelloRoute
 
                 .log("Card Created in '${header.ListName}': '${header.SlushyCardName}'")
 
-                .setHeader("ListInbox").constant(inboxConfig.getSourceList())
+                .setHeader("ListInbox", inboxConfig::getSourceList)
                 .filter().simple("${header.ListName} == ${header.ListInbox}")
                 .to("direct:Slushy.Card.Inbox")
         ;

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/withdraw/CardMovedWithdrawListenerRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/withdraw/CardMovedWithdrawListenerRoute.java
@@ -16,7 +16,7 @@ public class CardMovedWithdrawListenerRoute
     public void configure() throws Exception {
         from("seda:Slushy.WebHook.CardMoved?multipleConsumers=true")
                 .routeId("Slushy.WebHook.CardMoved.Withdrawn")
-                .setHeader("ListWithdrawn").constant(withdrawnConfig.getSourceList())
+                .setHeader("ListWithdrawn", withdrawnConfig::getSourceList)
                 .filter().simple("${header.SlushyMovedTo} == ${header.ListWithdrawn}")
                 .to("direct:Slushy.Card.Withdrawn")
         ;

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/withdraw/WithdrawTimerRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/withdraw/WithdrawTimerRoute.java
@@ -32,7 +32,7 @@ public class WithdrawTimerRoute
         fromF("timer:withdraw?period=%s", withdrawConfig.getScanPeriod())
                 .routeId("Slushy.Withdraw")
 
-                .setHeader("ListName").constant(withdrawConfig.getSourceList())
+                .setHeader("ListName", withdrawConfig::getSourceList)
                 .setBody().method(loadList)
                 .split(body())
 

--- a/slushy-parent/pom.xml
+++ b/slushy-parent/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy-parent</artifactId>
-    <version>2.4.0</version>
+    <version>2.5.0</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/slushy.sh
+++ b/slushy.sh
@@ -12,6 +12,8 @@ docker run -d \
        -e SLUSHY_READER \
        -e SLUSHY_WEBHOOK \
        -e SLUSHY_QUEUE \
+       -e SLUSHY_CONFIG_LIST \
+       -e SLUSHY_CONFIG_CARD \
        -e SLUSHY_STATUS_LIST \
        -e SLUSHY_STATUS_CARD \
        -e AWS_ACCESS_KEY \

--- a/slushy/pom.xml
+++ b/slushy/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.kemitix.slushy</groupId>
   <artifactId>slushy</artifactId>
-  <version>2.4.0</version>
+  <version>2.5.0</version>
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/slushy/src/main/java/net/kemitix/slushy/AbstractQuarkusListProcessingConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/AbstractQuarkusListProcessingConfig.java
@@ -2,11 +2,13 @@ package net.kemitix.slushy;
 
 import lombok.Getter;
 import lombok.Setter;
+import net.kemitix.slushy.app.config.AbstractDynamicConfig;
 import net.kemitix.slushy.app.ListProcessConfig;
 
 @Setter
 @Getter
 public abstract class AbstractQuarkusListProcessingConfig
+        extends AbstractDynamicConfig
         implements ListProcessConfig {
 
     long scanPeriod;

--- a/slushy/src/main/java/net/kemitix/slushy/AbstractQuarkusListProcessingConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/AbstractQuarkusListProcessingConfig.java
@@ -2,20 +2,27 @@ package net.kemitix.slushy;
 
 import lombok.Getter;
 import lombok.Setter;
-import net.kemitix.slushy.app.config.AbstractDynamicConfig;
 import net.kemitix.slushy.app.ListProcessConfig;
+
+import java.util.Properties;
 
 @Setter
 @Getter
 public abstract class AbstractQuarkusListProcessingConfig
-        extends AbstractDynamicConfig
+        extends AbstractQuarkusRetryConfig
         implements ListProcessConfig {
 
-    long scanPeriod;
-    String sourceList;
-    String targetList;
-    String routingSlip;
-    int requiredAgeHours;
-    long retryDelay;
+    private String sourceList;
+    private String targetList;
+    private String routingSlip;
+    private int requiredAgeHours;
 
+    @Override
+    public void update(Properties properties) {
+        super.update(properties);
+        update("source-list", this::setSourceList, properties);
+        update("target-list", this::setTargetList, properties);
+        update("routing-slip", this::setRoutingSlip, properties);
+        update("required-age-hours", Integer::parseInt, this::setRequiredAgeHours, properties);
+    }
 }

--- a/slushy/src/main/java/net/kemitix/slushy/AbstractQuarkusListProcessingConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/AbstractQuarkusListProcessingConfig.java
@@ -1,13 +1,9 @@
 package net.kemitix.slushy;
 
-import lombok.Getter;
 import lombok.Setter;
 import net.kemitix.slushy.app.ListProcessConfig;
 
-import java.util.Properties;
-
 @Setter
-@Getter
 public abstract class AbstractQuarkusListProcessingConfig
         extends AbstractQuarkusRetryConfig
         implements ListProcessConfig {
@@ -18,11 +14,27 @@ public abstract class AbstractQuarkusListProcessingConfig
     private int requiredAgeHours;
 
     @Override
-    public void update(Properties properties) {
-        super.update(properties);
-        update("source-list", this::setSourceList, properties);
-        update("target-list", this::setTargetList, properties);
-        update("routing-slip", this::setRoutingSlip, properties);
-        update("required-age-hours", Integer::parseInt, this::setRequiredAgeHours, properties);
+    public String getSourceList() {
+        return findValue("source-list")
+                .orElse(sourceList);
     }
+
+    @Override
+    public String getTargetList() {
+        return findValue("target-list")
+                .orElse(targetList);
+    }
+
+    @Override
+    public String getRoutingSlip() {
+        return findValue("routing-slip")
+                .orElse(routingSlip);
+    }
+
+    @Override
+    public int getRequiredAgeHours() {
+        return findIntegerValue("required-age-hours")
+                .orElse(requiredAgeHours);
+    }
+
 }

--- a/slushy/src/main/java/net/kemitix/slushy/AbstractQuarkusRetryConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/AbstractQuarkusRetryConfig.java
@@ -19,7 +19,8 @@ public abstract class AbstractQuarkusRetryConfig
     @Override
     public void update(Properties properties) {
         super.update(properties);
-        update("scan-period", Long::parseLong, this::setScanPeriod, properties);
+        //Not dynamically updatable
+        //update("scan-period", Long::parseLong, this::setScanPeriod, properties);
         update("retry-delay", Long::parseLong, this::setRetryDelay, properties);
     }
 

--- a/slushy/src/main/java/net/kemitix/slushy/AbstractQuarkusRetryConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/AbstractQuarkusRetryConfig.java
@@ -3,13 +3,24 @@ package net.kemitix.slushy;
 import lombok.Getter;
 import lombok.Setter;
 import net.kemitix.slushy.app.RetryConfig;
+import net.kemitix.slushy.app.config.AbstractDynamicConfig;
+
+import java.util.Properties;
 
 @Setter
 @Getter
 public abstract class AbstractQuarkusRetryConfig
+        extends AbstractDynamicConfig
         implements RetryConfig {
 
-    long scanPeriod;
-    long retryDelay;
+    private long scanPeriod;
+    private long retryDelay;
+
+    @Override
+    public void update(Properties properties) {
+        super.update(properties);
+        update("scan-period", Long::parseLong, this::setScanPeriod, properties);
+        update("retry-delay", Long::parseLong, this::setRetryDelay, properties);
+    }
 
 }

--- a/slushy/src/main/java/net/kemitix/slushy/AbstractQuarkusRetryConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/AbstractQuarkusRetryConfig.java
@@ -1,14 +1,10 @@
 package net.kemitix.slushy;
 
-import lombok.Getter;
 import lombok.Setter;
 import net.kemitix.slushy.app.RetryConfig;
 import net.kemitix.slushy.app.config.AbstractDynamicConfig;
 
-import java.util.Properties;
-
 @Setter
-@Getter
 public abstract class AbstractQuarkusRetryConfig
         extends AbstractDynamicConfig
         implements RetryConfig {
@@ -17,11 +13,14 @@ public abstract class AbstractQuarkusRetryConfig
     private long retryDelay;
 
     @Override
-    public void update(Properties properties) {
-        super.update(properties);
-        //Not dynamically updatable
-        //update("scan-period", Long::parseLong, this::setScanPeriod, properties);
-        update("retry-delay", Long::parseLong, this::setRetryDelay, properties);
+    public long getScanPeriod() {
+        return findLongValue("scan-period")
+                .orElse(scanPeriod);
     }
 
+    @Override
+    public long getRetryDelay() {
+        return findLongValue("retry-delay")
+                .orElse(retryDelay);
+    }
 }

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusArchiverConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusArchiverConfig.java
@@ -3,9 +3,16 @@ package net.kemitix.slushy;
 import io.quarkus.arc.config.ConfigProperties;
 import net.kemitix.slushy.app.archiver.ArchiverConfig;
 
-@ConfigProperties(prefix = "slushy.archiver")
+@ConfigProperties(prefix = QuarkusArchiverConfig.CONFIG_PREFIX)
 public class QuarkusArchiverConfig
         extends AbstractQuarkusListProcessingConfig
         implements ArchiverConfig {
+
+    protected static final String CONFIG_PREFIX = "slushy.archiver";
+
+    @Override
+    public String getConfigPrefix() {
+        return CONFIG_PREFIX;
+    }
 
 }

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusEmailConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusEmailConfig.java
@@ -3,9 +3,15 @@ package net.kemitix.slushy;
 import io.quarkus.arc.config.ConfigProperties;
 import net.kemitix.slushy.app.email.EmailConfig;
 
-@ConfigProperties(prefix = "slushy.email")
+@ConfigProperties(prefix = QuarkusEmailConfig.CONFIG_PREFIX)
 public class QuarkusEmailConfig
         extends AbstractQuarkusRetryConfig
         implements EmailConfig {
 
+    protected static final String CONFIG_PREFIX = "slushy.email";
+
+    @Override
+    public String getConfigPrefix() {
+        return CONFIG_PREFIX;
+    }
 }

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusEmailConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusEmailConfig.java
@@ -14,4 +14,5 @@ public class QuarkusEmailConfig
     public String getConfigPrefix() {
         return CONFIG_PREFIX;
     }
+
 }

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusHoldConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusHoldConfig.java
@@ -16,7 +16,7 @@ public class QuarkusHoldConfig
 
     protected static final String CONFIG_PREFIX = "slushy.hold";
 
-    private Long dueDays;
+    private long dueDays;
 
     @Override
     public String getConfigPrefix() {
@@ -25,6 +25,7 @@ public class QuarkusHoldConfig
 
     @Override
     public void update(Properties properties) {
+        super.update(properties);
         update("due-days", Long::parseLong, v -> {this.dueDays = v;}, properties);
     }
 

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusHoldConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusHoldConfig.java
@@ -1,14 +1,10 @@
 package net.kemitix.slushy;
 
 import io.quarkus.arc.config.ConfigProperties;
-import lombok.Getter;
 import lombok.Setter;
 import net.kemitix.slushy.app.hold.HoldConfig;
 
-import java.util.Properties;
-
 @Setter
-@Getter
 @ConfigProperties(prefix = QuarkusHoldConfig.CONFIG_PREFIX)
 public class QuarkusHoldConfig
         extends AbstractQuarkusListProcessingConfig
@@ -24,9 +20,9 @@ public class QuarkusHoldConfig
     }
 
     @Override
-    public void update(Properties properties) {
-        super.update(properties);
-        update("due-days", Long::parseLong, v -> {this.dueDays = v;}, properties);
+    public long getDueDays() {
+        return findLongValue("due-days")
+                .orElse(dueDays);
     }
 
 }

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusHoldConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusHoldConfig.java
@@ -5,13 +5,27 @@ import lombok.Getter;
 import lombok.Setter;
 import net.kemitix.slushy.app.hold.HoldConfig;
 
+import java.util.Properties;
+
 @Setter
 @Getter
-@ConfigProperties(prefix = "slushy.hold")
+@ConfigProperties(prefix = QuarkusHoldConfig.CONFIG_PREFIX)
 public class QuarkusHoldConfig
         extends AbstractQuarkusListProcessingConfig
         implements HoldConfig {
 
-    private long dueDays;
+    protected static final String CONFIG_PREFIX = "slushy.hold";
+
+    private Long dueDays;
+
+    @Override
+    public String getConfigPrefix() {
+        return CONFIG_PREFIX;
+    }
+
+    @Override
+    public void update(Properties properties) {
+        update("due-days", Long::parseLong, v -> {this.dueDays = v;}, properties);
+    }
 
 }

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusInboxConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusInboxConfig.java
@@ -4,14 +4,28 @@ import io.quarkus.arc.config.ConfigProperties;
 import lombok.Getter;
 import lombok.Setter;
 import net.kemitix.slushy.app.inbox.InboxConfig;
+import org.apache.velocity.runtime.directive.Parse;
+
+import java.util.Properties;
 
 @Setter
 @Getter
-@ConfigProperties(prefix = "slushy.inbox")
+@ConfigProperties(prefix = QuarkusInboxConfig.CONFIG_PREFIX)
 public class QuarkusInboxConfig
         extends AbstractQuarkusListProcessingConfig
         implements InboxConfig {
 
-    private long dueDays;
+    protected static final String CONFIG_PREFIX = "slushy.inbox";
 
+    private Long dueDays;
+
+    @Override
+    public String getConfigPrefix() {
+        return CONFIG_PREFIX;
+    }
+
+    @Override
+    public void update(Properties properties) {
+        update("due-days", Long::parseLong, this::setDueDays, properties);
+    }
 }

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusInboxConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusInboxConfig.java
@@ -17,7 +17,7 @@ public class QuarkusInboxConfig
 
     protected static final String CONFIG_PREFIX = "slushy.inbox";
 
-    private Long dueDays;
+    private long dueDays;
 
     @Override
     public String getConfigPrefix() {
@@ -26,6 +26,7 @@ public class QuarkusInboxConfig
 
     @Override
     public void update(Properties properties) {
+        super.update(properties);
         update("due-days", Long::parseLong, this::setDueDays, properties);
     }
 }

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusInboxConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusInboxConfig.java
@@ -1,15 +1,10 @@
 package net.kemitix.slushy;
 
 import io.quarkus.arc.config.ConfigProperties;
-import lombok.Getter;
 import lombok.Setter;
 import net.kemitix.slushy.app.inbox.InboxConfig;
-import org.apache.velocity.runtime.directive.Parse;
-
-import java.util.Properties;
 
 @Setter
-@Getter
 @ConfigProperties(prefix = QuarkusInboxConfig.CONFIG_PREFIX)
 public class QuarkusInboxConfig
         extends AbstractQuarkusListProcessingConfig
@@ -25,8 +20,9 @@ public class QuarkusInboxConfig
     }
 
     @Override
-    public void update(Properties properties) {
-        super.update(properties);
-        update("due-days", Long::parseLong, this::setDueDays, properties);
+    public long getDueDays() {
+        return findValue("due-days")
+                .map(Long::parseLong)
+                .orElse(dueDays);
     }
 }

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusMultiSubConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusMultiSubConfig.java
@@ -3,14 +3,30 @@ package net.kemitix.slushy;
 import io.quarkus.arc.config.ConfigProperties;
 import lombok.Getter;
 import lombok.Setter;
+import net.kemitix.slushy.app.config.AbstractDynamicConfig;
 import net.kemitix.slushy.app.multisub.MultiSubConfig;
+
+import java.util.Properties;
 
 @Setter
 @Getter
-@ConfigProperties(prefix = "slushy.multisub")
+@ConfigProperties(prefix = QuarkusMultiSubConfig.CONFIG_PREFIX)
 public class QuarkusMultiSubConfig
+        extends AbstractDynamicConfig
         implements MultiSubConfig {
+
+    protected static final String CONFIG_PREFIX = "slushy.multisub";
 
     String lists;
 
+    @Override
+    public void update(Properties properties) {
+        super.update(properties);
+        update("lists", this::setLists, properties);
+    }
+
+    @Override
+    public String getConfigPrefix() {
+        return CONFIG_PREFIX;
+    }
 }

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusMultiSubConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusMultiSubConfig.java
@@ -1,15 +1,11 @@
 package net.kemitix.slushy;
 
 import io.quarkus.arc.config.ConfigProperties;
-import lombok.Getter;
 import lombok.Setter;
 import net.kemitix.slushy.app.config.AbstractDynamicConfig;
 import net.kemitix.slushy.app.multisub.MultiSubConfig;
 
-import java.util.Properties;
-
 @Setter
-@Getter
 @ConfigProperties(prefix = QuarkusMultiSubConfig.CONFIG_PREFIX)
 public class QuarkusMultiSubConfig
         extends AbstractDynamicConfig
@@ -20,13 +16,14 @@ public class QuarkusMultiSubConfig
     String lists;
 
     @Override
-    public void update(Properties properties) {
-        super.update(properties);
-        update("lists", this::setLists, properties);
-    }
-
-    @Override
     public String getConfigPrefix() {
         return CONFIG_PREFIX;
     }
+
+    @Override
+    public String getLists() {
+        return findValue("lists")
+                .orElse(lists);
+    }
+
 }

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusReaderConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusReaderConfig.java
@@ -1,14 +1,10 @@
 package net.kemitix.slushy;
 
 import io.quarkus.arc.config.ConfigProperties;
-import lombok.Getter;
 import lombok.Setter;
 import net.kemitix.slushy.app.reader.ReaderConfig;
 
-import java.util.Properties;
-
 @Setter
-@Getter
 @ConfigProperties(prefix = QuarkusReaderConfig.CONFIG_PREFIX)
 public class QuarkusReaderConfig
         extends AbstractQuarkusListProcessingConfig
@@ -24,8 +20,9 @@ public class QuarkusReaderConfig
     }
 
     @Override
-    public void update(Properties properties) {
-        super.update(properties);
-        update("max-size", Integer::parseInt, this::setMaxSize, properties);
+    public int getMaxSize() {
+        return findIntegerValue("max-size")
+                .orElse(maxSize);
     }
+
 }

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusReaderConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusReaderConfig.java
@@ -5,13 +5,26 @@ import lombok.Getter;
 import lombok.Setter;
 import net.kemitix.slushy.app.reader.ReaderConfig;
 
+import java.util.Properties;
+
 @Setter
 @Getter
-@ConfigProperties(prefix = "slushy.reader")
+@ConfigProperties(prefix = QuarkusReaderConfig.CONFIG_PREFIX)
 public class QuarkusReaderConfig
         extends AbstractQuarkusListProcessingConfig
         implements ReaderConfig {
 
+    protected static final String CONFIG_PREFIX = "slushy.reader";
+
     private int maxSize;
 
+    @Override
+    public String getConfigPrefix() {
+        return CONFIG_PREFIX;
+    }
+
+    @Override
+    public void update(Properties properties) {
+        update("max-size", Integer::parseInt, this::setMaxSize, properties);
+    }
 }

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusReaderConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusReaderConfig.java
@@ -25,6 +25,7 @@ public class QuarkusReaderConfig
 
     @Override
     public void update(Properties properties) {
+        super.update(properties);
         update("max-size", Integer::parseInt, this::setMaxSize, properties);
     }
 }

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusRejectConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusRejectConfig.java
@@ -3,9 +3,16 @@ package net.kemitix.slushy;
 import io.quarkus.arc.config.ConfigProperties;
 import net.kemitix.slushy.app.reject.RejectConfig;
 
-@ConfigProperties(prefix = "slushy.reject")
+@ConfigProperties(prefix = QuarkusRejectConfig.CONFIG_PREFIX)
 public class QuarkusRejectConfig
         extends AbstractQuarkusListProcessingConfig
         implements RejectConfig {
+
+    protected static final String CONFIG_PREFIX = "slushy.reject";
+
+    @Override
+    public String getConfigPrefix() {
+        return CONFIG_PREFIX;
+    }
 
 }

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusStatusConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusStatusConfig.java
@@ -6,10 +6,7 @@ import lombok.Setter;
 import net.kemitix.slushy.app.config.AbstractDynamicConfig;
 import net.kemitix.slushy.app.status.StatusConfig;
 
-import java.util.Properties;
-
 @Setter
-@Getter
 @ConfigProperties(prefix = QuarkusStatusConfig.CONFIG_PREFIX)
 public class QuarkusStatusConfig
         extends AbstractDynamicConfig
@@ -18,17 +15,19 @@ public class QuarkusStatusConfig
     protected static final String CONFIG_PREFIX = "slushy.status";
 
     private int logPeriod;
+    @Getter
     private String listName = System.getenv("SLUSHY_STATUS_LIST");
+    @Getter
     private String cardName = System.getenv("SLUSHY_STATUS_CARD");
-
-    @Override
-    public void update(Properties properties) {
-        super.update(properties);
-        update("log-period", Integer::parseInt, this::setLogPeriod, properties);
-    }
 
     @Override
     public String getConfigPrefix() {
         return CONFIG_PREFIX;
+    }
+
+    @Override
+    public int getLogPeriod() {
+        return findIntegerValue("log-period")
+                .orElse(logPeriod);
     }
 }

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusStatusConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusStatusConfig.java
@@ -3,16 +3,32 @@ package net.kemitix.slushy;
 import io.quarkus.arc.config.ConfigProperties;
 import lombok.Getter;
 import lombok.Setter;
+import net.kemitix.slushy.app.config.AbstractDynamicConfig;
 import net.kemitix.slushy.app.status.StatusConfig;
+
+import java.util.Properties;
 
 @Setter
 @Getter
-@ConfigProperties(prefix = "slushy.status")
+@ConfigProperties(prefix = QuarkusStatusConfig.CONFIG_PREFIX)
 public class QuarkusStatusConfig
+        extends AbstractDynamicConfig
         implements StatusConfig {
+
+    protected static final String CONFIG_PREFIX = "slushy.status";
 
     private int logPeriod;
     private String listName = System.getenv("SLUSHY_STATUS_LIST");
     private String cardName = System.getenv("SLUSHY_STATUS_CARD");
 
+    @Override
+    public void update(Properties properties) {
+        super.update(properties);
+        update("log-period", Integer::parseInt, this::setLogPeriod, properties);
+    }
+
+    @Override
+    public String getConfigPrefix() {
+        return CONFIG_PREFIX;
+    }
 }

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusWithdrawConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusWithdrawConfig.java
@@ -3,9 +3,16 @@ package net.kemitix.slushy;
 import io.quarkus.arc.config.ConfigProperties;
 import net.kemitix.slushy.app.withdraw.WithdrawConfig;
 
-@ConfigProperties(prefix = "slushy.withdraw")
+@ConfigProperties(prefix = QuarkusWithdrawConfig.CONFIG_PREFIX)
 public class QuarkusWithdrawConfig
         extends AbstractQuarkusListProcessingConfig
         implements WithdrawConfig {
+
+    protected static final String CONFIG_PREFIX = "slushy.withdraw";
+
+    @Override
+    public String getConfigPrefix() {
+        return CONFIG_PREFIX;
+    }
 
 }

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusZeroAttachmentConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusZeroAttachmentConfig.java
@@ -3,14 +3,30 @@ package net.kemitix.slushy;
 import io.quarkus.arc.config.ConfigProperties;
 import lombok.Getter;
 import lombok.Setter;
+import net.kemitix.slushy.app.config.AbstractDynamicConfig;
 import net.kemitix.slushy.app.zeroattachment.ZeroAttachmentConfig;
+
+import java.util.Properties;
 
 @Setter
 @Getter
-@ConfigProperties(prefix = "slushy.zeroattachment")
+@ConfigProperties(prefix = QuarkusZeroAttachmentConfig.CONFIG_PREFIX)
 public class QuarkusZeroAttachmentConfig
+        extends AbstractDynamicConfig
         implements ZeroAttachmentConfig {
+
+    protected static final String CONFIG_PREFIX = "slushy.zeroattachment";
 
     String routingSlip;
 
+    @Override
+    public void update(Properties properties) {
+        super.update(properties);
+        update("routing-slip", this::setRoutingSlip, properties);
+    }
+
+    @Override
+    public String getConfigPrefix() {
+        return CONFIG_PREFIX;
+    }
 }

--- a/slushy/src/main/java/net/kemitix/slushy/QuarkusZeroAttachmentConfig.java
+++ b/slushy/src/main/java/net/kemitix/slushy/QuarkusZeroAttachmentConfig.java
@@ -1,15 +1,11 @@
 package net.kemitix.slushy;
 
 import io.quarkus.arc.config.ConfigProperties;
-import lombok.Getter;
 import lombok.Setter;
 import net.kemitix.slushy.app.config.AbstractDynamicConfig;
 import net.kemitix.slushy.app.zeroattachment.ZeroAttachmentConfig;
 
-import java.util.Properties;
-
 @Setter
-@Getter
 @ConfigProperties(prefix = QuarkusZeroAttachmentConfig.CONFIG_PREFIX)
 public class QuarkusZeroAttachmentConfig
         extends AbstractDynamicConfig
@@ -20,13 +16,13 @@ public class QuarkusZeroAttachmentConfig
     String routingSlip;
 
     @Override
-    public void update(Properties properties) {
-        super.update(properties);
-        update("routing-slip", this::setRoutingSlip, properties);
-    }
-
-    @Override
     public String getConfigPrefix() {
         return CONFIG_PREFIX;
     }
+
+    public String getRoutingSlip() {
+        return findValue("routing-slip")
+                .orElse(routingSlip);
+    }
+
 }


### PR DESCRIPTION
Environment variable specifies a card and list to be parsed for configuration settings.

- At startup use environment variables `SLUSHY_CONFIG_LIST` and `SLUSHY_CONFIG_CARD` to identify a card on the board to be used as a configuration source
- card body should be either properties format or yaml
- Using the existing webhook/sqs, when the card is updated, parse and update the configuration
- Settings loaded from the card override any of the existing settings loaded from the `application.properties` file