### PR TITLE
Don't prefix reader attachments with card id

### DIFF
--- a/slushy-app/src/main/java/net/kemitix/slushy/app/AttachmentLoader.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/AttachmentLoader.java
@@ -19,12 +19,31 @@ public class AttachmentLoader {
     @Inject
     AttachmentDirectory attachmentDirectory;
 
-    public LocalAttachment load(Card card) {
-        return CardWithAttachments.create(card, trello, attachmentDirectory)
+    public LocalAttachment load(
+            Card card,
+            Submission submission
+    ) {
+        Card c = cardWithoutIdInName(card, submission);
+        return CardWithAttachments.create(c, trello, attachmentDirectory)
                 .findAttachments()
                 .map(Attachment::download)
                 .findFirst()
                 .orElseGet(MissingAttachment::new);
+    }
+
+    private Card cardWithoutIdInName(
+            Card card,
+            Submission submission
+    ) {
+        Card c = new Card();
+        c.setId(card.getId());
+        c.setIdShort(card.getIdShort());
+        c.setName(String.format("%s by %s", submission.getTitle(), submission.getByline()));
+        return c;
+    }
+
+    private String getName(Card card) {
+        return card.getName();
     }
 
 }

--- a/slushy-app/src/main/java/net/kemitix/slushy/app/reader/LoadAttachmentRoute.java
+++ b/slushy-app/src/main/java/net/kemitix/slushy/app/reader/LoadAttachmentRoute.java
@@ -16,7 +16,7 @@ public class LoadAttachmentRoute
                 .routeId("Slushy.LoadAttachment")
 
                 .setHeader("SlushyAttachment")
-                .method(attachmentLoader, "load(${header.SlushyCard})")
+                .method(attachmentLoader, "load(${header.SlushyCard}, ${header.SlushySubmission})")
 
                 .choice()
                 .when(simple("${header.SlushyAttachment.isZero}"))


### PR DESCRIPTION
The story title is used for the statement name and that now already includes the card id, now causing the card id to appear twice on reader attachments.