### PR TITLE
Downgrade Apache Camel from 3.11.1 to 3.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <tiles-maven-plugin.version>2.22</tiles-maven-plugin.version>
         <kemitix-tiles.version>3.1.1</kemitix-tiles.version>
 
-        <camel.version>3.11.1</camel.version>
+        <camel.version>3.11.0</camel.version>
         <lombok.version>1.18.20</lombok.version>
         <javax.mail.version>1.5.0-b01</javax.mail.version>
         <aws-java-sdk-ses.version>1.12.19</aws-java-sdk-ses.version>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
 
     <properties>
         <tiles-maven-plugin.version>2.22</tiles-maven-plugin.version>


### PR DESCRIPTION
3.11.1 is causing a `ClassNotFoundException` for `org.apache.camel.spi.AutowiredLifecycleStrategy`

There is also a split package: "org.apache.camel.main" found in [org.apache.camel:camel-base-engine::jar, org.apache.camel:camel-main::jar]