### PR TITLE
Fix calibre extraction and upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2</version>
 
     <properties>
         <tiles-maven-plugin.version>2.22</tiles-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy</artifactId>
-    <version>3.2.2</version>
+    <version>3.2.3</version>
 
     <properties>
         <tiles-maven-plugin.version>2.22</tiles-maven-plugin.version>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && \
 # download and install calibre
 RUN wget -nv -O- \
     https://download.calibre-ebook.com/linux-installer.sh | \
-    sh /dev/stdin version=5.19.0
+    sh /dev/stdin version=5.26.0
 
 WORKDIR /app
 

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -26,8 +26,8 @@ FROM debian:stable
 # install wget and python required to download and install calibre, plus a JRE
 RUN apt-get update && \
     apt-get install -y \
-        wget=1.20.1-1.1 \
-        python3=3.7.3-1 \
+        wget=1.21-1+b1 \
+        python3=3.9.2-3 \
         openjdk-11-jre \
     && rm -rf /var/lib/apt/lists/*
 

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && \
         wget=1.21-1+b1 \
         python3=3.9.2-3 \
         openjdk-11-jre \
+        xz-utils=5.2.5-2 \
     && rm -rf /var/lib/apt/lists/*
 
 # download and install calibre


### PR DESCRIPTION
- Docker: Upgrade wget and python3 packages
- Version set to 3.2.2
- Dockerfile: add xz-utils to extract calibre
- Dockerfile: bump calibre from 5.19.0 to 5.26.0
- Version set to 3.2.3
