### PR TITLE
Should not be accessing private method in AttachmentLoader

### DIFF
--- a/src/main/java/net/kemitix/slushy/app/AttachmentLoader.java
+++ b/src/main/java/net/kemitix/slushy/app/AttachmentLoader.java
@@ -27,7 +27,7 @@ public class AttachmentLoader {
     AttachmentDirectory attachmentDirectory;
 
     @Inject
-    private AttachmentDownloadValidator attachmentDownloadValidator;
+    AttachmentDownloadValidator attachmentDownloadValidator;
 
     @Handler
     public LocalAttachment load(


### PR DESCRIPTION
Found unrecommended usage of private members (use package-private instead) in application beans:
        - @Inject field net.kemitix.slushy.app.AttachmentLoader#attachmentDownloadValidator