### PR TITLE
attempt to configure maven-git-versioning-extension

### DIFF
--- a/.git-versioned-pom.xml
+++ b/.git-versioned-pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>net.kemitix.slushy</groupId>
     <artifactId>slushy</artifactId>
-    <version>AUTO</version>
+    <version>root-0-g0000000</version>
 
     <properties>
         <tiles-maven-plugin.version>2.25</tiles-maven-plugin.version>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,10 @@
+<extensions xmlns="https://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="https://maven.apache.org/EXTENSIONS/1.0.0 https://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+
+    <extension>
+        <groupId>me.qoomon</groupId>
+        <artifactId>maven-git-versioning-extension</artifactId>
+        <version>7.2.3</version>
+    </extension>
+
+</extensions>

--- a/.mvn/maven-git-versioning-extension.xml
+++ b/.mvn/maven-git-versioning-extension.xml
@@ -1,0 +1,22 @@
+<configuration xmlns="https://github.com/qoomon/maven-git-versioning-extension"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="https://github.com/qoomon/maven-git-versioning-extension https://qoomon.github.io/maven-git-versioning-extension/configuration-7.0.0.xsd">
+
+    <refs>
+        <ref type="branch">
+            <pattern>.+</pattern>
+            <version>${describe}</version>
+        </ref>
+
+        <ref type="tag">
+            <pattern><![CDATA[v(?<version>.*)]]></pattern>
+            <version>${ref.version}</version>
+        </ref>
+    </refs>
+
+    <!-- optional fallback configuration in case of no matching ref configuration-->
+    <rev>
+        <version>${commit}</version>
+    </rev>
+
+</configuration>


### PR DESCRIPTION
Broken.

The command: `mvn help:evaluate -Dexpression=project.version -q -DforceStdout`

Outputs `root-0-g0000000`

When it should output, more like: `v3.3.0-3-g92ca75d`