### PR TITLE
Tag docker images with version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,5 +21,8 @@ dev:
 		-Dslushy.archiver.required-age-hours=0 \
 		-Dslushy.withdraw.scan-period=30000
 
+TAG := kemitix/slushy:$(shell git describe --tags)
+
 docker: clean install
-	docker build -f src/main/docker/Dockerfile -t kemitix/slushy .
+	docker build -f src/main/docker/Dockerfile -t ${TAG} .
+	docker tag ${TAG} kemitix/slushy

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -26,10 +26,10 @@ FROM debian:stable
 # install wget and python required to download and install calibre, plus a JRE
 RUN apt-get update && \
     apt-get install -y \
-        wget=1.21-1+b1 \
-        python3=3.9.2-3 \
-        openjdk-11-jre \
-        xz-utils=5.2.5-2 \
+        wget \
+        python3 \
+        openjdk-17-jre \
+        xz-utils \
     && rm -rf /var/lib/apt/lists/*
 
 # download and install calibre


### PR DESCRIPTION
- tag docker images with git describe based version
- Use versions available in debian:stable for apt-get packages
