### PR TITLE
Bump camel-bom from 3.15.0 to 3.18.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <kemitix-tiles.version>3.2.0</kemitix-tiles.version>
 
         <jakarta.jakartaee-api.version>9.1.0</jakarta.jakartaee-api.version>
-        <camel.version>3.15.0</camel.version>
+        <camel.version>3.18.2</camel.version>
         <lombok.version>1.18.24</lombok.version>
         <assertj.version>3.23.1</assertj.version>
         <junit.version>5.9.1</junit.version>


### PR DESCRIPTION
Bumps camel-bom from 3.15.0 to 3.18.2.

---
updated-dependencies:
- dependency-name: org.apache.camel:camel-bom
dependency-type: direct:production
update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

---

**Stack**:
- #485 ⬅
- #484
- #483
- #482
- #481


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*