### PR TITLE
Convert to epub for before sending to reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The card is validated and a precis insert at the start of the Card's description
 The Card, if valid, and email is sent to the author, and it is then moved to the _Send to Reader_ list.
 For Cards that fail validation, an email is sent to the author and the Card is moved to the _Rejected_ list.
 
-Cards are taken from the _Send to Reader_ list and converted, using Calibre, into Mobi format and sent to the `SLUSHY_READER` email address, presumably the address for a Kindle device.
+Cards are taken from the _Send to Reader_ list and converted, using Calibre, into EPub format and sent to the `SLUSHY_READER` email address, presumably the address for a Kindle device.
 The Card is then moved to the _Slush_ list.
 The setting `slushy.reader.max-size` within the properties file determines the maximum number of cards that will be added to the _Slush_ list at any one time.
 If there is no space in the _Slush_ list, then no cards are taken from the _Send to Reader_ list until there is.

--- a/src/main/java/net/kemitix/slushy/app/ValidFileTypes.java
+++ b/src/main/java/net/kemitix/slushy/app/ValidFileTypes.java
@@ -20,7 +20,7 @@ public class ValidFileTypes {
             "docx", "doc",
             "txt",
             "azw",
-            "mobi",
+            "epub",
             "html", "htm"
     );
 

--- a/src/main/java/net/kemitix/slushy/app/fileconversion/ConvertAttachment.java
+++ b/src/main/java/net/kemitix/slushy/app/fileconversion/ConvertAttachment.java
@@ -43,10 +43,10 @@ public class ConvertAttachment {
         File sourceFile = attachment.getFilename();
         String name = sourceFile.getName();
         log.info("Converting from " + name);
-        String mobiName = name.substring(0, name.lastIndexOf(".")) + ".mobi";
-        File mobiFile = attachmentDirectory.createFile(new File(mobiName));
-        log.info("Converting  to  " + mobiFile.getAbsolutePath());
-        return converter.convert(sourceFile, mobiFile, submission);
+        String epubName = name.substring(0, name.lastIndexOf(".")) + ".epub";
+        File epubFile = attachmentDirectory.createFile(new File(epubName));
+        log.info("Converting  to  " + epubFile.getAbsolutePath());
+        return converter.convert(sourceFile, epubFile, submission);
     }
 
 }

--- a/src/test/java/net/kemitix/slushy/app/cardparsers/ParseSubmissionTest.java
+++ b/src/test/java/net/kemitix/slushy/app/cardparsers/ParseSubmissionTest.java
@@ -196,10 +196,12 @@ public class ParseSubmissionTest
 
             // Kindle Personal Documents Service:
             // https://www.amazon.co.uk/gp/help/customer/display.html?nodeId=200767340
-            //        Kindle Format (.MOBI, .AZW)
+            //        EPUB (.EPUB)
             //        Microsoft Word (.DOC, .DOCX)
             //        HTML (.HTML, .HTM)
             //        Text (.TXT)
+            // No longer supports the newest Kindle features and genrates a return email for each document sent to Kindle
+            //        Kindle Format (.MOBI, .AZW)
             // The following types claim to be supported by Kindle, but aren't
             //        RTF (.RTF)
             //        PDF (.PDF)
@@ -210,7 +212,7 @@ public class ParseSubmissionTest
             //        BMP (.BMP)
             @ParameterizedTest
             @DisplayName("Accepts Kindle supported types")
-            @ValueSource(strings = {"MOBI", "AZW", "DOC", "DOCX", "HTML", "HTM", "TXT"})
+            @ValueSource(strings = {"EPUB", "DOC", "DOCX", "HTML", "HTM", "TXT"})
             public void acceptsKindleTypes(String type) {
                 documentUrl = "document." + type;
                 given(slushyBoard.getAttachments(card))
@@ -221,7 +223,7 @@ public class ParseSubmissionTest
 
             @ParameterizedTest
             @DisplayName("Accepts convertible types")
-            @ValueSource(strings = {"ODT", "RTF"})
+            @ValueSource(strings = {"ODT", "RTF", "MOBI"})
             public void acceptsConvertibleTypes(String type) {
                 documentUrl = "document." + type;
                 given(slushyBoard.getAttachments(card))
@@ -392,10 +394,12 @@ public class ParseSubmissionTest
 
             // Kindle Personal Documents Service:
             // https://www.amazon.co.uk/gp/help/customer/display.html?nodeId=200767340
-            //        Kindle Format (.MOBI, .AZW)
+            //        EPUB (.EPUB)
             //        Microsoft Word (.DOC, .DOCX)
             //        HTML (.HTML, .HTM)
             //        Text (.TXT)
+            // No longer supports the newest Kindle features and genrates a return email for each document sent to Kindle
+            //        Kindle Format (.MOBI, .AZW)
             // The following types claim to be supported by Kindle, but aren't
             //        RTF (.RTF)
             //        PDF (.PDF)
@@ -406,7 +410,7 @@ public class ParseSubmissionTest
             //        BMP (.BMP)
             @ParameterizedTest
             @DisplayName("Accepts Kindle supported types")
-            @ValueSource(strings = {"MOBI", "AZW", "DOC", "DOCX", "HTML", "HTM", "TXT"})
+            @ValueSource(strings = {"EPUB", "DOC", "DOCX", "HTML", "HTM", "TXT"})
             public void acceptsKindleTypes(String type) {
                 documentUrl = "document." + type;
                 given(slushyBoard.getAttachments(card))
@@ -417,7 +421,7 @@ public class ParseSubmissionTest
 
             @ParameterizedTest
             @DisplayName("Accepts convertible types")
-            @ValueSource(strings = {"ODT", "RTF"})
+            @ValueSource(strings = {"ODT", "RTF", "MOBI"})
             public void acceptsConvertibleTypes(String type) {
                 documentUrl = "document." + type;
                 given(slushyBoard.getAttachments(card))


### PR DESCRIPTION
Kindle Send to Document sends a warning email every time a MOBI file
is sent. EPUB is their suggested alternative.

commit-id:a4a308f8