### PR TITLE
Bump commons-text from 1.9 to 1.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <microprofile.version>5.0</microprofile.version>
         <resteasy-core-spi.version>4.6.0.Final</resteasy-core-spi.version>
         <kemitix-trello.version>2.0.1</kemitix-trello.version>
-        <commons-text.version>1.9</commons-text.version>
+        <commons-text.version>1.10.0</commons-text.version>
         <zt-exec.version>1.12</zt-exec.version>
 
         <maven.compiler.parameters>true</maven.compiler.parameters>


### PR DESCRIPTION
Bumps commons-text from 1.9 to 1.10.0.

---
updated-dependencies:
- dependency-name: org.apache.commons:commons-text
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

commit-id:c5291571

---

**Stack**:
- #496
- #501
- #500 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*