### PR TITLE
Bump camel-bom from 3.15.0 to 3.19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <kemitix-tiles.version>3.2.0</kemitix-tiles.version>
 
         <jakarta.jakartaee-api.version>9.1.0</jakarta.jakartaee-api.version>
-        <camel.version>3.15.0</camel.version>
+        <camel.version>3.19.0</camel.version>
         <lombok.version>1.18.24</lombok.version>
         <assertj.version>3.23.1</assertj.version>
         <junit.version>5.9.1</junit.version>

--- a/src/main/java/net/kemitix/slushy/app/email/SendEmailRoute.java
+++ b/src/main/java/net/kemitix/slushy/app/email/SendEmailRoute.java
@@ -34,7 +34,7 @@ public class SendEmailRoute
                         ":${header.SlushySubmission.email}" +
                         ":${header.SlushyCard.id}")
                 .skipDuplicate(true)
-                .messageIdRepository(MemoryIdempotentRepository::new)
+                .idempotentRepository(new MemoryIdempotentRepository())
 
                 .setHeader("SlushyRecipient").simple("${header.SlushySubmission.email}")
                 .setHeader("SlushySender", trelloConfig::getSender)

--- a/src/main/java/net/kemitix/slushy/app/reader/SendToReaderRoute.java
+++ b/src/main/java/net/kemitix/slushy/app/reader/SendToReaderRoute.java
@@ -38,8 +38,7 @@ public class SendToReaderRoute
 
                 .idempotentConsumer().simple("${header.SlushyCard.id}")
                 .skipDuplicate(true)
-                .messageIdRepository(() ->
-                        memoryIdempotentRepository(readerProperties.maxSize()))
+                .idempotentRepository(memoryIdempotentRepository(readerProperties.maxSize()))
 
                 .setHeader("SlushyRecipient", trelloConfig::getReader)
                 .setHeader("SlushySender", trelloConfig::getSender)

--- a/src/main/java/net/kemitix/slushy/app/status/StatusUpdateRoute.java
+++ b/src/main/java/net/kemitix/slushy/app/status/StatusUpdateRoute.java
@@ -21,7 +21,7 @@ public class StatusUpdateRoute
                 // Ignore additional messages sent within a second
                 .idempotentConsumer().method(this, "tick")
                 .skipDuplicate(true)
-                .messageIdRepository(MemoryIdempotentRepository::new)
+                .idempotentRepository(new MemoryIdempotentRepository())
 
                 .bean(logStatus)
         ;

--- a/src/main/java/net/kemitix/slushy/app/trello/queue/WebHookTrelloRoute.java
+++ b/src/main/java/net/kemitix/slushy/app/trello/queue/WebHookTrelloRoute.java
@@ -34,7 +34,7 @@ public class WebHookTrelloRoute
 
                 .idempotentConsumer().jsonpath("body-json.action.id")
                 .skipDuplicate(true)
-                .messageIdRepository(MemoryIdempotentRepository::new)
+                .idempotentRepository(new MemoryIdempotentRepository())
 
                 .setHeader("ActionType").jsonpath("body-json.action.type")
 


### PR DESCRIPTION
Bumps camel-bom from 3.15.0 to 3.19.0.

---
updated-dependencies:
- dependency-name: org.apache.camel:camel-bom
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

commit-id:6e9e77b9